### PR TITLE
Add .clang-format/.clang-tidy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming'
+WarningsAsErrors: '*'
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.EnumCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           camelBack
+  - key:             readability-identifier-naming.MemberCase
+    value:           camelBack
+  - key:             readability-identifier-naming.ParameterCase
+    value:           camelBack
+  - key:             readability-identifier-naming.UnionCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.VariableCase
+    value:           camelBack
+  - key:             readability-identifier-naming.IgnoreMainLikeFunctions
+    value:           1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
-int main( int argc, char** argv )
-{
-    // This program does very little.
-    return 0;
+int main(int argc, char **argv) {
+  // This program does very little.
+  return 0;
 }


### PR DESCRIPTION
This adds .clang-format/.clang-tidy files and
reformats main.cpp according to the style.

The style is the LLVM coding standard, except
the uppercase variable/parameter/member names.

Automatic checks for these on pull requests
will be added in the next commit.