### PR TITLE
cmake: add support for gflags

### DIFF
--- a/.github/workflows/adapted-cmake.yml
+++ b/.github/workflows/adapted-cmake.yml
@@ -26,7 +26,7 @@ jobs:
       # Install the tools we need
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build cmake clang-format-11 ccache
+        sudo apt-get install -y ninja-build cmake clang-format-11 ccache libgflags-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,3 +11,6 @@ set_target_properties(turboevents_main PROPERTIES
 set_target_properties(turboevents_main PROPERTIES OUTPUT_NAME turboevents)
 
 target_link_libraries(turboevents_main PRIVATE turboevents)
+
+find_package(gflags COMPONENTS nothreads_static)
+target_link_libraries(turboevents_main PRIVATE gflags)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,15 @@
 #include "turboevents.hpp"
 
+#include <gflags/gflags.h>
+
 int main(int argc, char **argv) {
+  gflags::SetUsageMessage("fast event generator");
+  gflags::SetVersionString("0.1");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
   // This program does very little.
   TurboEvents::TurboEvents turbo;
 
+  gflags::ShutDownCommandLineFlags();
   return 0;
 }


### PR DESCRIPTION
This adds support for using gflags to parse
command line options. The library is BSD-3
licensed and there is a Ubuntu package
available.