### PR TITLE
Add create method to TurboEvents

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -1,6 +1,8 @@
 #ifndef TURBOEVENTS_HPP
 #define TURBOEVENTS_HPP
 
+#include <memory>
+
 namespace TurboEvents {
 
 /// A class encapsulating an event generator
@@ -8,6 +10,8 @@ class TurboEvents {
 public:
   /// Simple constructor
   TurboEvents();
+  /// Create a new TurboEvents object.
+  static std::unique_ptr<TurboEvents> create();
 };
 
 } // namespace TurboEvents

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -6,4 +6,8 @@ namespace TurboEvents {
 
 TurboEvents::TurboEvents() { std::cout << "TurboEvents initialized\n"; }
 
+std::unique_ptr<TurboEvents> TurboEvents::create() {
+  return std::make_unique<TurboEvents>();
+}
+
 } // namespace TurboEvents

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,8 +7,7 @@ int main(int argc, char **argv) {
   gflags::SetVersionString("0.1");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-  // This program does very little.
-  TurboEvents::TurboEvents turbo;
+  auto turbo = TurboEvents::TurboEvents::create();
 
   gflags::ShutDownCommandLineFlags();
   return 0;


### PR DESCRIPTION
This encapsulates the memory management
inside TurboEvents so the client can
call create and treat the return value
like a stack-allocated object.

This change is preparation for handling
faulty/incompatible command line parameters.