### PR TITLE
cmake: add Xerces detection support

### DIFF
--- a/.github/workflows/adapted-cmake.yml
+++ b/.github/workflows/adapted-cmake.yml
@@ -28,7 +28,7 @@ jobs:
       # Install the tools we need
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build cmake clang-tidy-12 ccache libgflags-dev graphviz doxygen
+        sudo apt-get install -y ninja-build cmake clang-tidy-12 ccache libgflags-dev graphviz doxygen libxerces-c-dev
 
     - name: Check code formatting
       run: |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,3 +15,6 @@ target_link_libraries(turboevents_main PRIVATE turboevents)
 
 find_package(gflags COMPONENTS nothreads_static)
 target_link_libraries(turboevents_main PRIVATE gflags)
+
+find_package(XercesC REQUIRED)
+target_link_libraries(turboevents_main PRIVATE "${XercesC_LIBRARIES}")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,24 @@
 #include "turboevents.hpp"
 
 #include <gflags/gflags.h>
+#include <xercesc/util/PlatformUtils.hpp>
+
+using namespace xercesc;
 
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");
   gflags::SetVersionString("0.1");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
+  try {
+    XMLPlatformUtils::Initialize();
+  } catch (const XMLException &e) {
+    return 1;
+  }
+
   auto turbo = TurboEvents::TurboEvents::create();
 
+  XMLPlatformUtils::Terminate();
   gflags::ShutDownCommandLineFlags();
   return 0;
 }


### PR DESCRIPTION
This adds the detection of Xerces to cmake
and calls the Initialize/Terminate methods
in main.

The library will be used in a future patch.