### PR TITLE
cmake: add support for sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ if(CCACHE_PROGRAM)
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()
 
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-fsanitize=undefined COMPILER_HAS_UBSAN)
+# FIXME (CMake 3.19): Add COMPILER_HAS_ASAN check (requires linker flags).
+
 option(CLANG_TIDY "Run clang-tidy with the compiler." ON)
 
 if(CLANG_TIDY)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,3 +8,10 @@ set_target_properties(turboevents PROPERTIES
 )
 
 target_include_directories(turboevents PUBLIC ${TurboEvents_SOURCE_DIR}/include)
+
+if(COMPILER_HAS_UBSAN)
+    target_compile_options(turboevents PUBLIC
+        $<$<CONFIG:Debug>:-fsanitize=undefined,address>)
+    target_link_options(turboevents PUBLIC
+        $<$<CONFIG:Debug>:-fsanitize=undefined,address>)
+endif()


### PR DESCRIPTION
This adds ubsan/asan to the Debug build
when they are available on the system.

While asan is fast for a memory checker,
there is still a 2-3x slowdown compared
to running without it. Always adding asan
when it is available keeps the build system
simple though, the release build should be used
when performance is a concern.