### PR TITLE
cmake: enable compiler warnings

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,6 +9,11 @@ set_target_properties(turboevents PROPERTIES
 
 target_include_directories(turboevents PUBLIC ${TurboEvents_SOURCE_DIR}/include)
 
+target_compile_options(turboevents PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 if(COMPILER_HAS_UBSAN)
     target_compile_options(turboevents PUBLIC
         $<$<CONFIG:Debug>:-fsanitize=undefined,address>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,11 @@ set_target_properties(turboevents_main PROPERTIES OUTPUT_NAME turboevents)
 
 target_link_libraries(turboevents_main PRIVATE turboevents)
 
+target_compile_options(turboevents_main PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
 find_package(gflags COMPONENTS nothreads_static)
 target_link_libraries(turboevents_main PRIVATE gflags)
 


### PR DESCRIPTION
CMake is currently lacking special support
for enabling compiler warnings so do a best
effort attempt that distinguishes between
MSVC and everything else. These lines can be
refined further in the future if we need to
support a compiler that is not sufficiently
GCC-compatible.