### PR TITLE
First runnable sketch of event library.

### DIFF
--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -1,13 +1,33 @@
 #include "turboevents.hpp"
 
 #include <iostream>
+#include <thread>
 
 namespace TurboEvents {
 
-TurboEvents::TurboEvents() { std::cout << "TurboEvents initialized\n"; }
+bool TurboEvents::lessES(const EventStream *a, const EventStream *b) {
+  return a->time > b->time;
+}
+
+TurboEvents::TurboEvents() : q(lessES) {
+  std::cout << "TurboEvents initialized\n";
+}
 
 std::unique_ptr<TurboEvents> TurboEvents::create() {
   return std::make_unique<TurboEvents>();
+}
+
+void TurboEvents::addEventStream(EventStream *s) { q.push(s); }
+
+void TurboEvents::run() {
+  while (!q.empty()) {
+    EventStream *es = q.top();
+    q.pop();
+    std::this_thread::sleep_until(es->time);
+    es->getNext()->trigger();
+    if (es->generate())
+      q.push(es); // Push the stream back on the queue if there are more events
+  }
 }
 
 } // namespace TurboEvents

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,52 @@
 #include "turboevents.hpp"
 
 #include <gflags/gflags.h>
+#include <iostream>
 #include <xercesc/util/PlatformUtils.hpp>
 
 using namespace xercesc;
+
+/// Dummy event type
+class SimpleEvent : public TurboEvents::Event {
+public:
+  /// Constructor
+  SimpleEvent(int m, std::chrono::system_clock::time_point t)
+      : Event(t), n(m) {}
+
+  /// Destructor
+  virtual ~SimpleEvent() override {}
+
+  /// Trigger
+  void trigger() const override { std::cout << "SimpleEvent " << n << "\n"; }
+
+private:
+  const int n; ///< Value to print
+};
+
+/// Dummy event stream
+class SimpleEventStream : public TurboEvents::EventStream {
+public:
+  /// Constructor
+  SimpleEventStream(int m, int i = 1000)
+      : EventStream(nullptr), n(m), interval(i) {
+    (void)generate();
+  }
+
+  /// Generator
+  bool generate() override {
+    if (next != nullptr) delete next;
+    if (n <= 0) return false;
+    next = new SimpleEvent(n, std::chrono::system_clock::now() +
+                                  std::chrono::milliseconds(interval));
+    time = next->time;
+    n--;
+    return true;
+  }
+
+private:
+  int n;              ///< How many events to generate
+  const int interval; ///< Interval in ms between events
+};
 
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");
@@ -17,6 +60,12 @@ int main(int argc, char **argv) {
   }
 
   auto turbo = TurboEvents::TurboEvents::create();
+
+  SimpleEventStream es(5);
+  SimpleEventStream fs(2, 1500);
+  turbo->addEventStream(&es);
+  turbo->addEventStream(&fs);
+  turbo->run();
 
   XMLPlatformUtils::Terminate();
   gflags::ShutDownCommandLineFlags();


### PR DESCRIPTION
The library uses a std::priority_queue to hold EventStreams, each of
which generate a sequence of events. The baseclass of events is Event
and each application should subclass it to add application specific
data. Similarly, EventStream is the baseclass of event streams and is
sub classed to add the specific event generation functionality.