### PR TITLE
Add Kafka support

### DIFF
--- a/.github/workflows/adapted-cmake.yml
+++ b/.github/workflows/adapted-cmake.yml
@@ -24,7 +24,7 @@ jobs:
       # Install the tools we need
       run: |
         sudo apt-get update
-        sudo apt-get install -y ninja-build clang-tidy-12 ccache libgflags-dev graphviz doxygen libxerces-c-dev
+        sudo apt-get install -y ninja-build clang-tidy-12 ccache libgflags-dev graphviz doxygen libxerces-c-dev librdkafka-dev
         sudo snap install cmake --classic
 
     - name: Check code formatting

--- a/lib/IO/CMakeLists.txt
+++ b/lib/IO/CMakeLists.txt
@@ -1,3 +1,8 @@
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(kafka REQUIRED IMPORTED_TARGET rdkafka)
+target_sources(turboevents PRIVATE KafkaOutput.cpp)
+target_link_libraries(turboevents PUBLIC PkgConfig::kafka)
+
 find_package(XercesC REQUIRED)
 target_sources(turboevents PRIVATE XMLInput.cpp)
-target_link_libraries(turboevents PUBLIC "${XercesC_LIBRARIES}") 
+target_link_libraries(turboevents PUBLIC "${XercesC_LIBRARIES}")

--- a/lib/IO/KafkaOutput.cpp
+++ b/lib/IO/KafkaOutput.cpp
@@ -1,0 +1,63 @@
+#include "KafkaOutput.hpp"
+#include <iostream>
+#include <librdkafka/rdkafkacpp.h>
+#include <string>
+
+namespace TurboEvents {
+
+/// The callback for when events have been received.
+class DeliveryReportCb : public RdKafka::DeliveryReportCb {
+public:
+  /// Callback method.
+  void dr_cb(RdKafka::Message &message) {
+    if (message.err())
+      std::cerr << "% Message delivery failed: " << message.errstr() << "\n";
+  }
+};
+
+void KafkaOutput::trigger() const {
+  std::string brokers = "localhost";
+  std::string topic = "measurements";
+
+  std::string errstr;
+
+  RdKafka::Conf *c = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
+  if (c->set("bootstrap.servers", brokers, errstr) != RdKafka::Conf::CONF_OK) {
+    std::cerr << errstr << "\n";
+    exit(1);
+  }
+
+  DeliveryReportCb drCb;
+  if (c->set("dr_cb", &drCb, errstr) != RdKafka::Conf::CONF_OK) {
+    std::cerr << errstr << "\n";
+    exit(1);
+  }
+
+  RdKafka::Producer *p = RdKafka::Producer::create(c, errstr);
+  if (!p) {
+    std::cerr << "Failed to create producer: " << errstr << "\n";
+    exit(1);
+  }
+  delete c;
+
+retry:
+  RdKafka::ErrorCode err = p->produce(
+      topic, RdKafka::Topic::PARTITION_UA, RdKafka::Producer::RK_MSG_COPY,
+      const_cast<char *>(data.c_str()), data.size(), NULL, 0, 0, NULL, NULL);
+
+  if (err != RdKafka::ERR_NO_ERROR) {
+    std::cerr << "% Failed to produce to topic " << topic << ": "
+              << RdKafka::err2str(err) << "\n";
+    if (err == RdKafka::ERR__QUEUE_FULL) {
+      p->poll(1000);
+      goto retry;
+    }
+  }
+  p->poll(0);
+  p->flush(10 * 1000);
+  if (p->outq_len() > 0)
+    std::cerr << "% " << p->outq_len() << " message(s) were not delivered\n";
+  delete p;
+}
+
+} // namespace TurboEvents

--- a/lib/IO/KafkaOutput.hpp
+++ b/lib/IO/KafkaOutput.hpp
@@ -1,0 +1,14 @@
+#include "turboevents.hpp"
+
+namespace TurboEvents {
+
+/// Class for sending Kafka events.
+class KafkaOutput : public Event {
+  /// The data to send.
+  std::string data;
+  KafkaOutput(std::chrono::system_clock::time_point t, std::string d)
+      : Event(t), data(d) {}
+  void trigger() const override;
+};
+
+} // namespace TurboEvents


### PR DESCRIPTION
This adds a basic event that sends Kafka
messages when triggered.

The event trigger sets up the Kafka connection
and uses a hardcoded configuration to so the
input side has something to do with its input.
This commit does not add anything that uses the
object. These limitations will be lifted in later
commits.