### PR TITLE
Give run() all streams to use in the form of Input objects.

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -43,6 +43,8 @@ protected:
   Event *next;
 };
 
+class Input;
+
 /// A class encapsulating an event generator
 class TurboEvents {
 public:
@@ -61,7 +63,7 @@ public:
   void addStreamsFromFile(const char *fileName);
 
   /// Run the event streams added so far
-  void run();
+  void run(std::vector<Input *> &input);
 
 private:
   /// Compare EventStream objects based on time
@@ -73,6 +75,56 @@ private:
   std::priority_queue<EventStream *, std::vector<EventStream *>,
                       decltype(&greaterES)>
       q;
+};
+
+/// A class encapsulating an input, such as a file
+class Input {
+public:
+  /// Virtual destructor
+  virtual ~Input() {}
+
+  /// A virtual function to add the event streams in the input to the event
+  /// generator
+  virtual void addStreams(TurboEvents &turbo) = 0;
+};
+
+/// An input class encapsulating an input file
+class FileInput : public Input {
+public:
+  /// Constructor
+  FileInput(const char *fileName) : fname(fileName) {}
+
+  /// Virtual Destructor
+  virtual ~FileInput() {}
+
+  /// Add the streams contained in the file
+  void addStreams(TurboEvents &turbo) override {
+    turbo.addStreamsFromFile(fname);
+  }
+
+private:
+  /// The name of the file
+  const char *fname;
+};
+
+/// An input class encapsulating a single event stream
+class StreamInput : public Input {
+public:
+  /// Constructor
+  StreamInput(EventStream *s) : stream(s) {}
+
+  /// Virtual Destructor
+  virtual ~StreamInput() {}
+
+  /// Add the stream
+  void addStreams(TurboEvents &turbo) override {
+    turbo.addEventStream(stream);
+    stream = nullptr;
+  }
+
+private:
+  /// The event stream
+  EventStream *stream;
 };
 
 } // namespace TurboEvents

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -36,7 +36,8 @@ void TurboEvents::addStreamsFromFile(const char *fileName) {
   xmlInput->addStreamsFromXMLFile(this, fileName);
 }
 
-void TurboEvents::run() {
+void TurboEvents::run(std::vector<Input *> &inputs) {
+  for (Input *input : inputs) input->addStreams(*this);
   while (!q.empty()) {
     EventStream *es = q.top();
     q.pop();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,13 +52,25 @@ int main(int argc, char **argv) {
 
   auto turbo = TurboEvents::TurboEvents::create();
 
-  for (int i = 1; i < argc; i++) turbo->addStreamsFromFile(argv[i]);
+  std::vector<TurboEvents::Input *> inputs = {};
+
+  for (int i = 1; i < argc; i++)
+    inputs.push_back(new TurboEvents::FileInput(argv[i]));
 
   SimpleEventStream *es = new SimpleEventStream(5);
   SimpleEventStream *fs = new SimpleEventStream(2, 1500);
-  turbo->addEventStream(es);
-  turbo->addEventStream(fs);
-  turbo->run();
+
+  auto *esStream = new TurboEvents::StreamInput(es);
+  auto *fsStream = new TurboEvents::StreamInput(fs);
+
+  inputs.push_back(esStream);
+  inputs.push_back(fsStream);
+
+  turbo->run(inputs);
+
+  for (auto *input : inputs) {
+    delete input;
+  }
 
   gflags::ShutDownCommandLineFlags();
   return 0;


### PR DESCRIPTION
A first sttep. I'm not totally happy with the memory management, but the argument to run() needs to be a vector of pointers in order for it to be polymorphic and some of the pointers must be heap allocated since we're iterating over the command line arguments. Hence all elements of the vector need to be heap allocated.

On another note, maybe the deallocation of the elements of the input vector should also be in run()?