### PR TITLE
Provide opaque constructors for Input subclassses

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -52,20 +52,17 @@ public:
   TurboEvents();
   /// Create a new TurboEvents object.
   static std::unique_ptr<TurboEvents> create();
+  /// Create a new XML file input.
+  static Input *createXMLFileInput(const char *name);
+  /// Create a new StreamInput object.
+  static Input *createStreamInput(int m, int i = 1000);
 
   /// Virtual destructor
   virtual ~TurboEvents();
 
-  /// Add an event stream
-  void addEventStream(EventStream *s);
-
-  /// Add one or more event streams from a file
-  void addStreamsFromFile(const char *fileName);
-
-  /// Run the event streams added so far
+  /// Run the event generator and process events.
   void run(std::vector<Input *> &input);
 
-private:
   /// Compare EventStream objects based on time
   static bool greaterES(const EventStream *a, const EventStream *b) {
     return a->time > b->time;
@@ -85,46 +82,11 @@ public:
 
   /// A virtual function to add the event streams in the input to the event
   /// generator
-  virtual void addStreams(TurboEvents &turbo) = 0;
-};
-
-/// An input class encapsulating an input file
-class FileInput : public Input {
-public:
-  /// Constructor
-  FileInput(const char *fileName) : fname(fileName) {}
-
-  /// Virtual Destructor
-  virtual ~FileInput() {}
-
-  /// Add the streams contained in the file
-  void addStreams(TurboEvents &turbo) override {
-    turbo.addStreamsFromFile(fname);
-  }
-
-private:
-  /// The name of the file
-  const char *fname;
-};
-
-/// An input class encapsulating a single event stream
-class StreamInput : public Input {
-public:
-  /// Constructor
-  StreamInput(EventStream *s) : stream(s) {}
-
-  /// Virtual Destructor
-  virtual ~StreamInput() {}
-
-  /// Add the stream
-  void addStreams(TurboEvents &turbo) override {
-    turbo.addEventStream(stream);
-    stream = nullptr;
-  }
-
-private:
-  /// The event stream
-  EventStream *stream;
+  virtual void
+  addStreams(std::priority_queue<EventStream *, std::vector<EventStream *>,
+                                 decltype(&TurboEvents::greaterES)> &q) = 0;
+  /// Deallocate resources used by the class.
+  virtual void finish() = 0;
 };
 
 } // namespace TurboEvents

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -9,6 +9,24 @@ using namespace xercesc;
 
 namespace TurboEvents {
 
+/// An input class encapsulating an XML input file
+class XMLFileInput : public Input {
+public:
+  /// Constructor
+  XMLFileInput(const char *fileName) : fname(fileName) {}
+  virtual ~XMLFileInput() {}
+
+  void addStreams(
+      std::priority_queue<EventStream *, std::vector<EventStream *>,
+                          decltype(&TurboEvents::greaterES)> &q) override;
+
+  void finish() override;
+
+private:
+  /// The name of the file
+  const char *fname;
+};
+
 /// Placeholder event class
 class XMLEvent : public Event {
 public:
@@ -57,11 +75,16 @@ public:
   virtual ~XMLInput();
 
   /// Open an XML-file and add one or more event streams based on its contents
-  void addStreamsFromXMLFile(TurboEvents *turbo, const char *fileName);
+  void addStreamsFromXMLFile(
+      std::priority_queue<EventStream *, std::vector<EventStream *>,
+                          decltype(&TurboEvents::greaterES)> &q,
+      const char *fileName);
 
 private:
   /// Parser objects for open files
   std::vector<DOMLSParser *> openDocs;
+  /// Event stream objects for open streams.
+  std::vector<XMLEventStream *> streams;
 };
 
 } // namespace TurboEvents

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,48 +3,6 @@
 #include <gflags/gflags.h>
 #include <iostream>
 
-/// Dummy event type
-class SimpleEvent : public TurboEvents::Event {
-public:
-  /// Constructor
-  SimpleEvent(int m, std::chrono::system_clock::time_point t)
-      : Event(t), n(m) {}
-
-  /// Destructor
-  virtual ~SimpleEvent() override {}
-
-  /// Trigger
-  void trigger() const override { std::cout << "SimpleEvent " << n << "\n"; }
-
-private:
-  const int n; ///< Value to print
-};
-
-/// Dummy event stream
-class SimpleEventStream : public TurboEvents::EventStream {
-public:
-  /// Constructor
-  SimpleEventStream(int m, int i = 1000)
-      : EventStream(nullptr), n(m), interval(i) {
-    (void)generate();
-  }
-
-  /// Generator
-  bool generate() override {
-    if (next != nullptr) delete next;
-    if (n <= 0) return false;
-    next = new SimpleEvent(n, std::chrono::system_clock::now() +
-                                  std::chrono::milliseconds(interval));
-    time = next->time;
-    n--;
-    return true;
-  }
-
-private:
-  int n;              ///< How many events to generate
-  const int interval; ///< Interval in ms between events
-};
-
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");
   gflags::SetVersionString("0.1");
@@ -52,19 +10,13 @@ int main(int argc, char **argv) {
 
   auto turbo = TurboEvents::TurboEvents::create();
 
-  std::vector<TurboEvents::Input *> inputs = {};
+  std::vector<TurboEvents::Input *> inputs;
 
-  for (int i = 1; i < argc; i++)
-    inputs.push_back(new TurboEvents::FileInput(argv[i]));
+  for (int i = 1; i < argc; ++i)
+    inputs.emplace_back(TurboEvents::TurboEvents::createXMLFileInput(argv[i]));
 
-  SimpleEventStream *es = new SimpleEventStream(5);
-  SimpleEventStream *fs = new SimpleEventStream(2, 1500);
-
-  auto *esStream = new TurboEvents::StreamInput(es);
-  auto *fsStream = new TurboEvents::StreamInput(fs);
-
-  inputs.push_back(esStream);
-  inputs.push_back(fsStream);
+  inputs.emplace_back(TurboEvents::TurboEvents::createStreamInput(5));
+  inputs.emplace_back(TurboEvents::TurboEvents::createStreamInput(2, 1500));
 
   turbo->run(inputs);
 


### PR DESCRIPTION
This allows us to stop exposing the internal details
of the Input subclasses and Event/EventStream subclasses.
This makes main.cpp into a straight consumer of
the library without any implementation parts.
The changes also allows moving the static xmlInput variable
into XMLInput.cpp and manage the lifetime of that object
by the XMLFileInput object instead of the TurboEvents
object.

There are still internal details exposed in the interface
so as an intermediate step this commit removes the
private declaration of TurboEvents::greaterES and
the priority queue. These are still considered private
variables of the TurboEvents class and should not
be used from main. They will be moved into the private
parts of the library in a future commit.