### PR TITLE
Make Input and Event/EventStream internal

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -1,48 +1,14 @@
 #ifndef TURBOEVENTS_HPP
 #define TURBOEVENTS_HPP
 
-#include <chrono>
+#include <functional>
 #include <memory>
 #include <queue>
 #include <vector>
 
 namespace TurboEvents {
 
-/// A type for events with time stamps
-struct Event {
-  /// Constructor
-  Event(std::chrono::system_clock::time_point t) : time(t) {}
-  /// Virtual destructor
-  virtual ~Event() {}
-  /// The time stamp of the event
-  const std::chrono::system_clock::time_point time;
-  /// Function to call when the time is right
-  virtual void trigger() const = 0;
-};
-
-/// A class for event streams where the events of the stream are delivered in
-/// order
-class EventStream {
-public:
-  /// Constructor
-  EventStream(Event *e) : next(e) {}
-  /// Virtual destructor
-  virtual ~EventStream() {}
-  /// Get next event
-  Event *getNext() const { return next; }
-
-  /// Generate the next event and write it to next returning true if an event
-  /// was found
-  virtual bool generate() = 0;
-
-  /// The time stamp of the first event
-  std::chrono::system_clock::time_point time;
-
-protected:
-  /// The next event
-  Event *next;
-};
-
+class EventStream;
 class Input;
 
 /// A class encapsulating an event generator
@@ -63,30 +29,12 @@ public:
   /// Run the event generator and process events.
   void run(std::vector<Input *> &input);
 
-  /// Compare EventStream objects based on time
-  static bool greaterES(const EventStream *a, const EventStream *b) {
-    return a->time > b->time;
-  }
-
+private:
   /// Priority queue containing EventStreams
-  std::priority_queue<EventStream *, std::vector<EventStream *>,
-                      decltype(&greaterES)>
+  std::priority_queue<
+      EventStream *, std::vector<EventStream *>,
+      std::function<bool(const EventStream *, const EventStream *)>>
       q;
-};
-
-/// A class encapsulating an input, such as a file
-class Input {
-public:
-  /// Virtual destructor
-  virtual ~Input() {}
-
-  /// A virtual function to add the event streams in the input to the event
-  /// generator
-  virtual void
-  addStreams(std::priority_queue<EventStream *, std::vector<EventStream *>,
-                                 decltype(&TurboEvents::greaterES)> &q) = 0;
-  /// Deallocate resources used by the class.
-  virtual void finish() = 0;
 };
 
 } // namespace TurboEvents

--- a/lib/IO/CMakeLists.txt
+++ b/lib/IO/CMakeLists.txt
@@ -1,3 +1,5 @@
+target_include_directories(turboevents PRIVATE ${TurboEvents_SOURCE_DIR}/lib)
+
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(kafka REQUIRED IMPORTED_TARGET rdkafka)
 target_sources(turboevents PRIVATE KafkaOutput.cpp)

--- a/lib/IO/KafkaOutput.hpp
+++ b/lib/IO/KafkaOutput.hpp
@@ -1,4 +1,4 @@
-#include "turboevents.hpp"
+#include "turboevents-internal.hpp"
 
 namespace TurboEvents {
 

--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -14,8 +14,9 @@ namespace TurboEvents {
 static XMLInput *xmlInput = nullptr;
 
 void XMLFileInput::addStreams(
-    std::priority_queue<EventStream *, std::vector<EventStream *>,
-                        decltype(&TurboEvents::greaterES)> &q) {
+    std::priority_queue<
+        EventStream *, std::vector<EventStream *>,
+        std::function<bool(const EventStream *, const EventStream *)>> &q) {
   // First, ensure that the XML system is up and running.
   if (xmlInput == nullptr) xmlInput = new XMLInput();
   xmlInput->addStreamsFromXMLFile(q, fname);
@@ -43,8 +44,9 @@ XMLInput::~XMLInput() {
 }
 
 void XMLInput::addStreamsFromXMLFile(
-    std::priority_queue<EventStream *, std::vector<EventStream *>,
-                        decltype(&TurboEvents::greaterES)> &q,
+    std::priority_queue<
+        EventStream *, std::vector<EventStream *>,
+        std::function<bool(const EventStream *, const EventStream *)>> &q,
     const char *fileName) {
   XMLCh tempStr[100];
   XMLString::transcode("LS", tempStr, 99);

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -3,7 +3,7 @@
 
 #include <xercesc/dom/DOM.hpp>
 
-#include "turboevents.hpp"
+#include "turboevents-internal.hpp"
 
 using namespace xercesc;
 
@@ -16,9 +16,10 @@ public:
   XMLFileInput(const char *fileName) : fname(fileName) {}
   virtual ~XMLFileInput() {}
 
-  void addStreams(
-      std::priority_queue<EventStream *, std::vector<EventStream *>,
-                          decltype(&TurboEvents::greaterES)> &q) override;
+  void addStreams(std::priority_queue<
+                  EventStream *, std::vector<EventStream *>,
+                  std::function<bool(const EventStream *, const EventStream *)>>
+                      &q) override;
 
   void finish() override;
 
@@ -76,8 +77,9 @@ public:
 
   /// Open an XML-file and add one or more event streams based on its contents
   void addStreamsFromXMLFile(
-      std::priority_queue<EventStream *, std::vector<EventStream *>,
-                          decltype(&TurboEvents::greaterES)> &q,
+      std::priority_queue<
+          EventStream *, std::vector<EventStream *>,
+          std::function<bool(const EventStream *, const EventStream *)>> &q,
       const char *fileName);
 
 private:

--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -1,0 +1,70 @@
+#ifndef TURBOEVENTS_INTERNAL_HPP
+#define TURBOEVENTS_INTERNAL_HPP
+
+#include "turboevents.hpp"
+#include <chrono>
+#include <functional>
+#include <queue>
+#include <vector>
+
+namespace TurboEvents {
+
+/// A type for events with time stamps
+struct Event {
+  /// Constructor
+  Event(std::chrono::system_clock::time_point t) : time(t) {}
+  /// Virtual destructor
+  virtual ~Event() {}
+  /// The time stamp of the event
+  const std::chrono::system_clock::time_point time;
+  /// Function to call when the time is right
+  virtual void trigger() const = 0;
+};
+
+/// A class for event streams where the events of the stream are delivered in
+/// order
+class EventStream {
+public:
+  /// Constructor
+  EventStream(Event *e) : next(e) {}
+  /// Virtual destructor
+  virtual ~EventStream() {}
+  /// Get next event
+  Event *getNext() const { return next; }
+
+  /// Generate the next event and write it to next returning true if an event
+  /// was found
+  virtual bool generate() = 0;
+
+  /// The time stamp of the first event
+  std::chrono::system_clock::time_point time;
+
+protected:
+  /// The next event
+  Event *next;
+};
+
+/// Compare EventStream objects based on time
+static inline bool greaterES(const EventStream *a, const EventStream *b) {
+  return a->time > b->time;
+}
+
+/// A class encapsulating an input, such as a file
+class Input {
+public:
+  /// Virtual destructor
+  virtual ~Input() {}
+
+  /// A virtual function to add the event streams in the input to the event
+  /// generator
+  virtual void addStreams(
+      std::priority_queue<EventStream *, std::vector<EventStream *>,
+                          std::function<bool(const EventStream *,
+                                             const EventStream *)>> &q) = 0;
+  /// Deallocate resources used by the class.
+  virtual void finish() = 0;
+};
+
+} // namespace TurboEvents
+
+#endif

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -1,5 +1,5 @@
-#include "turboevents.hpp"
 #include "IO/XMLInput.hpp"
+#include "turboevents-internal.hpp"
 
 #include <iostream>
 #include <thread>
@@ -14,9 +14,10 @@ public:
 
   virtual ~StreamInput() {}
 
-  void addStreams(
-      std::priority_queue<EventStream *, std::vector<EventStream *>,
-                          decltype(&TurboEvents::greaterES)> &q) override {
+  void addStreams(std::priority_queue<
+                  EventStream *, std::vector<EventStream *>,
+                  std::function<bool(const EventStream *, const EventStream *)>>
+                      &q) override {
     q.push(stream);
   }
 


### PR DESCRIPTION
This moves the Input, Event and EventStream classes
into a new internal header.

To decouple this I had to describe the type of
the priority queue in TurboEvents in a different
way which gives some domino effects in the other
parts of the code, but there should be no functional
change.

External users of the library should continue to include
turboevents.hpp, things inside lib/ should include
turboevents-internal.hpp instead after this change.