### PR TITLE
Make XMLInput private to XMLInput.cpp

### DIFF
--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -11,6 +11,29 @@ using namespace xercesc;
 
 namespace TurboEvents {
 
+/// Class managing the XML handling
+class XMLInput {
+public:
+  /// Constructor
+  XMLInput();
+
+  /// Destructor
+  virtual ~XMLInput();
+
+  /// Open an XML-file and add one or more event streams based on its contents
+  void addStreamsFromXMLFile(
+      std::priority_queue<
+          EventStream *, std::vector<EventStream *>,
+          std::function<bool(const EventStream *, const EventStream *)>> &q,
+      const char *fileName);
+
+private:
+  /// Parser objects for open files
+  std::vector<DOMLSParser *> openDocs;
+  /// Event stream objects for open streams.
+  std::vector<XMLEventStream *> streams;
+};
+
 static XMLInput *xmlInput = nullptr;
 
 void XMLFileInput::addStreams(

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -66,28 +66,5 @@ private:
   XMLSize_t nextIdx;
 };
 
-/// Class managing the XML handling
-class XMLInput {
-public:
-  /// Constructor
-  XMLInput();
-
-  /// Destructor
-  virtual ~XMLInput();
-
-  /// Open an XML-file and add one or more event streams based on its contents
-  void addStreamsFromXMLFile(
-      std::priority_queue<
-          EventStream *, std::vector<EventStream *>,
-          std::function<bool(const EventStream *, const EventStream *)>> &q,
-      const char *fileName);
-
-private:
-  /// Parser objects for open files
-  std::vector<DOMLSParser *> openDocs;
-  /// Event stream objects for open streams.
-  std::vector<XMLEventStream *> streams;
-};
-
 } // namespace TurboEvents
 #endif


### PR DESCRIPTION
This is an internal helper class so avoid
making it visible outside the cpp file.