### PR TITLE
Consolidate Event subclasses

### DIFF
--- a/lib/IO/IO.hpp
+++ b/lib/IO/IO.hpp
@@ -1,0 +1,19 @@
+#ifndef IO_HPP
+#define IO_HPP
+
+#include "PrintOutput.hpp"
+
+namespace TurboEvents {
+
+static inline Event *makeStringEvent(std::chrono::system_clock::time_point t,
+                                     std::string data) {
+  return new PrintEvent<std::string>(t, data);
+}
+
+static inline Event *makeIntEvent(std::chrono::system_clock::time_point t,
+                                  int data) {
+  return new PrintEvent<int>(t, data);
+}
+
+} // namespace TurboEvents
+#endif

--- a/lib/IO/KafkaOutput.hpp
+++ b/lib/IO/KafkaOutput.hpp
@@ -1,3 +1,6 @@
+#ifndef KAFKAOUTPUT_HPP
+#define KAFKAOUTPUT_HPP
+
 #include "turboevents-internal.hpp"
 
 namespace TurboEvents {
@@ -12,3 +15,4 @@ class KafkaOutput : public Event {
 };
 
 } // namespace TurboEvents
+#endif

--- a/lib/IO/PrintOutput.hpp
+++ b/lib/IO/PrintOutput.hpp
@@ -1,0 +1,28 @@
+#ifndef PRINTOUTPUT_HPP
+#define PRINTOUTPUT_HPP
+
+#include "turboevents-internal.hpp"
+
+#include <iostream>
+
+namespace TurboEvents {
+
+/// Event that prints its data to standard output.
+template <typename T> class PrintEvent : public Event {
+public:
+  /// Constructor
+  PrintEvent(std::chrono::system_clock::time_point t, T data)
+      : Event(t), d(data) {}
+
+  /// Destructor
+  virtual ~PrintEvent() override {}
+
+  /// Prints the data to standard output.
+  void trigger() const override { std::cout << d << "\n"; }
+
+private:
+  const T d; ///< Value to print
+};
+
+} // namespace TurboEvents
+#endif

--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -1,4 +1,5 @@
 #include "XMLInput.hpp"
+#include "IO.hpp"
 
 #include <ctime>
 #include <iomanip>
@@ -119,8 +120,6 @@ void XMLInput::addStreamsFromXMLFile(
   openDocs.push_back(parser);
 }
 
-void XMLEvent::trigger() const { std::cout << d << "\n"; }
-
 XMLEventStream::XMLEventStream(DOMNodeList *events)
     : EventStream(nullptr), xmlEvents(events), nextIdx(0) {
   generate();
@@ -149,7 +148,7 @@ bool XMLEventStream::generate() {
   XMLString::release(&timeStamp);
   auto tp = std::chrono::system_clock::from_time_t(std::mktime(&timeBuf));
 
-  next = new XMLEvent(tp, value);
+  next = makeStringEvent(tp, value);
   // The value string has been converted to a std::string by the call above and
   // is no longer used.
   XMLString::release(&value);

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -28,24 +28,6 @@ private:
   const char *fname;
 };
 
-/// Placeholder event class
-class XMLEvent : public Event {
-public:
-  /// Constructor
-  XMLEvent(std::chrono::system_clock::time_point t, std::string data)
-      : Event(t), d(data) {}
-
-  /// Virtual destructor
-  ~XMLEvent() {}
-
-  /// XML specific implementation of trigger
-  void trigger() const override;
-
-private:
-  /// Event data
-  std::string d;
-};
-
 /// An event stream that is read from an XML file
 class XMLEventStream : public EventStream {
 public:

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -1,3 +1,4 @@
+#include "IO/IO.hpp"
 #include "IO/XMLInput.hpp"
 #include "turboevents-internal.hpp"
 
@@ -28,23 +29,6 @@ private:
   EventStream *stream;
 };
 
-/// Dummy event type
-class SimpleEvent : public Event {
-public:
-  /// Constructor
-  SimpleEvent(int m, std::chrono::system_clock::time_point t)
-      : Event(t), n(m) {}
-
-  /// Destructor
-  virtual ~SimpleEvent() override {}
-
-  /// Trigger
-  void trigger() const override { std::cout << "SimpleEvent " << n << "\n"; }
-
-private:
-  const int n; ///< Value to print
-};
-
 /// Dummy event stream
 class SimpleEventStream : public EventStream {
 public:
@@ -58,8 +42,9 @@ public:
   bool generate() override {
     if (next != nullptr) delete next;
     if (n <= 0) return false;
-    next = new SimpleEvent(n, std::chrono::system_clock::now() +
-                                  std::chrono::milliseconds(interval));
+    next = makeIntEvent(std::chrono::system_clock::now() +
+                            std::chrono::milliseconds(interval),
+                        n);
     time = next->time;
     n--;
     return true;


### PR DESCRIPTION
Printing events to standard output is useful
for testing EventStream implementations against
an expected output. Consolidate the existing
Event subclasses that print to standard output
into a single class and use that instead of
the specialized classes.