### PR TITLE
Remove debug printouts

### DIFF
--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -57,14 +57,12 @@ XMLInput::XMLInput() {
   } catch (const XMLException &e) {
     exit(1);
   }
-  std::cout << "XML initialized\n";
 }
 
 XMLInput::~XMLInput() {
   for (auto *parser : openDocs) parser->release();
   for (auto *stream : streams) delete stream;
   XMLPlatformUtils::Terminate();
-  std::cout << "XML terminated\n";
 }
 
 void XMLInput::addStreamsFromXMLFile(
@@ -97,8 +95,6 @@ void XMLInput::addStreamsFromXMLFile(
     std::cerr << "Unexpected Exception\n";
     exit(-1);
   }
-
-  std::cout << "Read and parsed file " << fileName << "\n";
 
   XMLCh *ns = XMLString::transcode("*");
   XMLCh *tag = XMLString::transcode("glucose_level");

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -2,7 +2,6 @@
 #include "IO/XMLInput.hpp"
 #include "turboevents-internal.hpp"
 
-#include <iostream>
 #include <thread>
 
 namespace TurboEvents {
@@ -55,9 +54,7 @@ private:
   const int interval; ///< Interval in ms between events
 };
 
-TurboEvents::TurboEvents() : q(greaterES) {
-  std::cout << "TurboEvents initialized\n";
-}
+TurboEvents::TurboEvents() : q(greaterES) {}
 
 TurboEvents::~TurboEvents() {}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,6 @@
 #include "turboevents.hpp"
 
 #include <gflags/gflags.h>
-#include <iostream>
 
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");


### PR DESCRIPTION
The printouts report the state of internal objects
in the library which was useful before we had
the complete functionality but since everything works
now, remove the printouts. This also reduces the risk
that test outputs will change from internal refactoring.