### PR TITLE
cmake: add "check" target for tests

### DIFF
--- a/.github/workflows/adapted-cmake.yml
+++ b/.github/workflows/adapted-cmake.yml
@@ -39,14 +39,15 @@ jobs:
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -G "Ninja Multi-Config"
 
+    # We can build the check target immediately, but building the default
+    # target first allows us to see if the CI fails because of the build
+    # or the test.
     - name: Build
       run: |
         cmake --build ${{github.workspace}}/build --config Debug
         cmake --build ${{github.workspace}}/build --config Release
 
     - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C Release
-      
+      run: |
+        cmake --build ${{github.workspace}}/build --config Debug --target check
+        cmake --build ${{github.workspace}}/build --config Release --target check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ if(DOXYGEN)
     set_target_properties(doxygen PROPERTIES EXCLUDE_FROM_ALL $<CONFIG:Release>)
 endif()
 
-# add the source, library and include directories so that cmake can find them
-add_subdirectory(src)
+# Add the subdirectories with the sources.
 add_subdirectory(lib)
+add_subdirectory(src)
+add_subdirectory(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+include(CTest)
+
+include(ProcessorCount)
+ProcessorCount(N)
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -j${N})
+
+# Test fixture to build the main binary which is required by most tests.
+add_test(NAME test_build
+  COMMAND "${CMAKE_COMMAND}"
+             --build "${CMAKE_BINARY_DIR}" --config "$<CONFIG>" -j${N}
+	     --target turboevents_main)
+set_tests_properties(test_build PROPERTIES FIXTURES_SETUP test_fixture)
+
+# Each test to run, and their test_fixture to manage dependencies.
+add_test(NAME xml_test
+  COMMAND $<TARGET_FILE:turboevents_main>
+            ${TurboEvents_SOURCE_DIR}/test/events1.xml
+            ${TurboEvents_SOURCE_DIR}/test/events2.xml)
+set_tests_properties(xml_test PROPERTIES FIXTURES_REQUIRED test_fixture)


### PR DESCRIPTION
This adds a "check" target that will build
and run the tests.