### PR TITLE
Keep events in a std::vector in XMLEventStream.

### DIFF
--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -32,7 +32,7 @@ private:
 class XMLEventStream : public EventStream {
 public:
   /// Constructor
-  XMLEventStream(DOMNodeList *events);
+  XMLEventStream(std::vector<Event *> events);
 
   /// Destructor
   virtual ~XMLEventStream() {}
@@ -41,11 +41,11 @@ public:
   bool generate() override;
 
 private:
-  /// List of XML events to read from
-  DOMNodeList *xmlEvents;
+  /// The events of this stream
+  std::vector<Event *> eventVec;
 
-  /// Index of next event to deliver
-  XMLSize_t nextIdx;
+  /// Index of next event to generate
+  size_t eventIdx;
 };
 
 } // namespace TurboEvents


### PR DESCRIPTION
Read all events from an XML file immediately and place them in
a std::vector in the XMLEventStream object rather than keeping
the events in the DOM object and reading them one at a time.