### PR TITLE
cmake: add option for disabling sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ if(CCACHE_PROGRAM)
     set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 endif()
 
+option(SANITIZERS "Build with Sanitizers." ON)
+
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag(-fsanitize=undefined COMPILER_HAS_UBSAN)
 # FIXME (CMake 3.19): Add COMPILER_HAS_ASAN check (requires linker flags).

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,7 +14,7 @@ target_compile_options(turboevents PRIVATE
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
 )
 
-if(COMPILER_HAS_UBSAN)
+if(SANITIZERS AND COMPILER_HAS_UBSAN)
     target_compile_options(turboevents PUBLIC
         $<$<CONFIG:Debug>:-fsanitize=undefined,address>)
     target_link_options(turboevents PUBLIC


### PR DESCRIPTION
Valgrind requires some sanitizers to be disabled
so add an option to the build system to do that.