### PR TITLE
Use std::unique_ptr for Input objects

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -9,7 +9,22 @@
 namespace TurboEvents {
 
 class EventStream;
-class Input;
+
+/// A class encapsulating an input, such as a file
+class Input {
+public:
+  /// Virtual destructor
+  virtual ~Input() = 0;
+
+  /// A virtual function to add the event streams in the input to the event
+  /// generator
+  virtual void addStreams(
+      std::priority_queue<EventStream *, std::vector<EventStream *>,
+                          std::function<bool(const EventStream *,
+                                             const EventStream *)>> &q) = 0;
+  /// Deallocate resources used by the class.
+  virtual void finish() = 0;
+};
 
 /// A class encapsulating an event generator
 class TurboEvents {
@@ -19,15 +34,15 @@ public:
   /// Create a new TurboEvents object.
   static std::unique_ptr<TurboEvents> create();
   /// Create a new XML file input.
-  static Input *createXMLFileInput(const char *name);
+  static std::unique_ptr<Input> createXMLFileInput(const char *name);
   /// Create a new StreamInput object.
-  static Input *createStreamInput(int m, int i = 1000);
+  static std::unique_ptr<Input> createStreamInput(int m, int i = 1000);
 
   /// Virtual destructor
   virtual ~TurboEvents();
 
   /// Run the event generator and process events.
-  void run(std::vector<Input *> &input);
+  void run(std::vector<std::unique_ptr<Input>> &input);
 
 private:
   /// Priority queue containing EventStreams

--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -49,22 +49,6 @@ static inline bool greaterES(const EventStream *a, const EventStream *b) {
   return a->time > b->time;
 }
 
-/// A class encapsulating an input, such as a file
-class Input {
-public:
-  /// Virtual destructor
-  virtual ~Input() {}
-
-  /// A virtual function to add the event streams in the input to the event
-  /// generator
-  virtual void addStreams(
-      std::priority_queue<EventStream *, std::vector<EventStream *>,
-                          std::function<bool(const EventStream *,
-                                             const EventStream *)>> &q) = 0;
-  /// Deallocate resources used by the class.
-  virtual void finish() = 0;
-};
-
 } // namespace TurboEvents
 
 #endif

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -6,6 +6,8 @@
 
 namespace TurboEvents {
 
+Input::~Input() = default;
+
 /// An input class encapsulating a single event stream
 class StreamInput : public Input {
 public:
@@ -62,16 +64,16 @@ std::unique_ptr<TurboEvents> TurboEvents::create() {
   return std::make_unique<TurboEvents>();
 }
 
-Input *TurboEvents::createXMLFileInput(const char *name) {
-  return new XMLFileInput(name);
+std::unique_ptr<Input> TurboEvents::createXMLFileInput(const char *name) {
+  return std::make_unique<XMLFileInput>(name);
 }
 
-Input *TurboEvents::createStreamInput(int m, int i) {
-  return new StreamInput(new SimpleEventStream(m, i));
+std::unique_ptr<Input> TurboEvents::createStreamInput(int m, int i) {
+  return std::make_unique<StreamInput>(new SimpleEventStream(m, i));
 }
 
-void TurboEvents::run(std::vector<Input *> &inputs) {
-  for (Input *input : inputs) input->addStreams(q);
+void TurboEvents::run(std::vector<std::unique_ptr<Input>> &inputs) {
+  for (auto &input : inputs) input->addStreams(q);
   while (!q.empty()) {
     EventStream *es = q.top();
     q.pop();
@@ -80,10 +82,7 @@ void TurboEvents::run(std::vector<Input *> &inputs) {
     if (es->generate())
       q.push(es); // Push the stream back on the queue if there are more events
   }
-  for (Input *input : inputs) {
-    input->finish();
-    delete input;
-  }
+  for (auto &input : inputs) input->finish();
 }
 
 } // namespace TurboEvents

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,13 +9,13 @@ int main(int argc, char **argv) {
 
   auto turbo = TurboEvents::TurboEvents::create();
 
-  std::vector<TurboEvents::Input *> inputs;
+  std::vector<std::unique_ptr<TurboEvents::Input>> inputs;
 
   for (int i = 1; i < argc; ++i)
-    inputs.emplace_back(TurboEvents::TurboEvents::createXMLFileInput(argv[i]));
+    inputs.push_back(TurboEvents::TurboEvents::createXMLFileInput(argv[i]));
 
-  inputs.emplace_back(TurboEvents::TurboEvents::createStreamInput(5));
-  inputs.emplace_back(TurboEvents::TurboEvents::createStreamInput(2, 1500));
+  inputs.push_back(TurboEvents::TurboEvents::createStreamInput(5));
+  inputs.push_back(TurboEvents::TurboEvents::createStreamInput(2, 1500));
 
   turbo->run(inputs);
 


### PR DESCRIPTION
This requires making the abstract class Input
visible to main so the destructor can be seen,
but no implementation details are exposed
so this is fine.