### PR TITLE
Internalize the comparison function

### DIFF
--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -44,11 +44,6 @@ protected:
   Event *next;
 };
 
-/// Compare EventStream objects based on time
-static inline bool greaterES(const EventStream *a, const EventStream *b) {
-  return a->time > b->time;
-}
-
 } // namespace TurboEvents
 
 #endif

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -73,6 +73,9 @@ std::unique_ptr<Input> TurboEvents::createStreamInput(int m, int i) {
 }
 
 void TurboEvents::run(std::vector<std::unique_ptr<Input>> &inputs) {
+  auto greaterES = [](const EventStream *a, const EventStream *b) {
+    return a->time > b->time;
+  };
   std::priority_queue<
       EventStream *, std::vector<EventStream *>,
       std::function<bool(const EventStream *, const EventStream *)>>


### PR DESCRIPTION
There is no longer any need to expose
this function outside run().

This should have been a part of commit
d0587cd93e79f4 that internalized the
priority queue.