### PR TITLE
Stop exposing the priority queue

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -3,7 +3,6 @@
 
 #include <functional>
 #include <memory>
-#include <queue>
 #include <vector>
 
 namespace TurboEvents {
@@ -16,12 +15,8 @@ public:
   /// Virtual destructor
   virtual ~Input() = 0;
 
-  /// A virtual function to add the event streams in the input to the event
-  /// generator
-  virtual void addStreams(
-      std::priority_queue<EventStream *, std::vector<EventStream *>,
-                          std::function<bool(const EventStream *,
-                                             const EventStream *)>> &q) = 0;
+  /// Add the event streams in the input to the event generator.
+  virtual void addStreams(std::function<void(EventStream *)> push) = 0;
   /// Deallocate resources used by the class.
   virtual void finish() = 0;
 };

--- a/lib/IO/KafkaOutput.hpp
+++ b/lib/IO/KafkaOutput.hpp
@@ -2,6 +2,7 @@
 #define KAFKAOUTPUT_HPP
 
 #include "turboevents-internal.hpp"
+#include <string>
 
 namespace TurboEvents {
 

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -1,11 +1,8 @@
 #ifndef XMLINPUT_HPP
 #define XMLINPUT_HPP
 
-#include <xercesc/dom/DOM.hpp>
-
 #include "turboevents-internal.hpp"
-
-using namespace xercesc;
+#include "turboevents.hpp"
 
 namespace TurboEvents {
 
@@ -16,10 +13,7 @@ public:
   XMLFileInput(const char *fileName) : fname(fileName) {}
   virtual ~XMLFileInput() {}
 
-  void addStreams(std::priority_queue<
-                  EventStream *, std::vector<EventStream *>,
-                  std::function<bool(const EventStream *, const EventStream *)>>
-                      &q) override;
+  void addStreams(std::function<void(EventStream *)> push) override;
 
   void finish() override;
 

--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -1,11 +1,7 @@
 #ifndef TURBOEVENTS_INTERNAL_HPP
 #define TURBOEVENTS_INTERNAL_HPP
 
-#include "turboevents.hpp"
 #include <chrono>
-#include <functional>
-#include <queue>
-#include <vector>
 
 namespace TurboEvents {
 


### PR DESCRIPTION
This hides the priority queue behind
an opaque function that is created
in run(). Passing a reference to the queue
is much faster, but these parts of the code
are only run in the setup-phase which is not
performance critical.