### PR TITLE
Delete events after completing run()

### DIFF
--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -136,7 +136,6 @@ XMLEventStream::XMLEventStream(std::vector<Event *> events)
     : EventStream(nullptr), eventVec(events), eventIdx(0) {}
 
 bool XMLEventStream::generate(Output &) {
-  if (next != nullptr) delete next;
   if (eventIdx >= eventVec.size()) return false;
   next = eventVec[eventIdx];
   eventIdx++;

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -30,7 +30,9 @@ public:
   XMLEventStream(std::vector<Event *> events);
 
   /// Destructor
-  virtual ~XMLEventStream() {}
+  virtual ~XMLEventStream() {
+    for (auto *e : eventVec) delete e;
+  }
 
   /// Generator
   bool generate(Output &output) override;


### PR DESCRIPTION
This moves the memory deallocation from
the performance sensitive XMLEventStream::generate()
to the XMLEventStream destructor.