### PR TITLE
Internalize the abstract Input class

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -2,13 +2,10 @@
 #define TURBOEVENTS_HPP
 
 #include <chrono>
-#include <functional>
 #include <memory>
-#include <vector>
 
 namespace TurboEvents {
 
-class EventStream;
 struct Event;
 
 /// A class encapsulating an output destination
@@ -29,19 +26,6 @@ protected:
   void unimp(std::string className, std::string typeName);
 };
 
-/// A class encapsulating an input, such as a file
-class Input {
-public:
-  /// Virtual destructor
-  virtual ~Input() = 0;
-
-  /// Add the event streams in the input to the event generator.
-  virtual void addStreams(Output &output,
-                          std::function<void(EventStream *)> push) = 0;
-  /// Deallocate resources used by the class.
-  virtual void finish() = 0;
-};
-
 /// A class encapsulating an event generator
 class TurboEvents {
 public:
@@ -50,9 +34,9 @@ public:
   /// Create a new TurboEvents object.
   static std::unique_ptr<TurboEvents> create();
   /// Create a new XML file input.
-  static std::unique_ptr<Input> createXMLFileInput(const char *name);
+  virtual void createXMLFileInput(const char *name) = 0;
   /// Create a new StreamInput object.
-  static std::unique_ptr<Input> createStreamInput(int m, int i = 1000);
+  virtual void createStreamInput(int m, int i = 1000) = 0;
 
   /// Create a new PrintOutput object
   static std::unique_ptr<Output> createPrintOutput();
@@ -64,7 +48,7 @@ public:
   virtual ~TurboEvents();
 
   /// Run the event generator and process events.
-  void run(Output &output, std::vector<std::unique_ptr<Input>> &input);
+  virtual void run(Output &output) = 0;
 };
 
 } // namespace TurboEvents

--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -2,11 +2,26 @@
 #define TURBOEVENTS_INTERNAL_HPP
 
 #include <chrono>
+#include <functional>
 #include <string>
 
 namespace TurboEvents {
 
+class EventStream;
 class Output;
+
+/// A class encapsulating an input, such as a file
+class Input {
+public:
+  /// Virtual destructor
+  virtual ~Input() = 0;
+
+  /// Add the event streams in the input to the event generator.
+  virtual void addStreams(Output &output,
+                          std::function<void(EventStream *)> push) = 0;
+  /// Deallocate resources used by the class.
+  virtual void finish() = 0;
+};
 
 /// A type for events with time stamps
 struct Event {

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -53,20 +53,29 @@ private:
   const int interval; ///< Interval in ms between events
 };
 
+/// The real TurboEvents implementation.
+class TurboEventsImpl : public TurboEvents {
+public:
+  /// Constructor.
+  TurboEventsImpl() : inputs() {}
+  ~TurboEventsImpl() {}
+
+  void createXMLFileInput(const char *name) override;
+  void createStreamInput(int m, int i) override;
+
+  void run(Output &output) override;
+
+private:
+  /// The input sources for the run.
+  std::vector<std::unique_ptr<Input>> inputs;
+};
+
 TurboEvents::TurboEvents() {}
 
-TurboEvents::~TurboEvents() {}
+TurboEvents::~TurboEvents() = default;
 
 std::unique_ptr<TurboEvents> TurboEvents::create() {
-  return std::make_unique<TurboEvents>();
-}
-
-std::unique_ptr<Input> TurboEvents::createXMLFileInput(const char *name) {
-  return std::make_unique<XMLFileInput>(name);
-}
-
-std::unique_ptr<Input> TurboEvents::createStreamInput(int m, int i) {
-  return std::make_unique<StreamInput>(new SimpleEventStream(m, i));
+  return std::make_unique<TurboEventsImpl>();
 }
 
 std::unique_ptr<Output> TurboEvents::createPrintOutput() {
@@ -86,8 +95,15 @@ std::unique_ptr<Output> TurboEvents::createOutput(std::string &s) {
   return output;
 }
 
-void TurboEvents::run(Output &output,
-                      std::vector<std::unique_ptr<Input>> &inputs) {
+void TurboEventsImpl::createXMLFileInput(const char *name) {
+  inputs.push_back(std::make_unique<XMLFileInput>(name));
+}
+
+void TurboEventsImpl::createStreamInput(int m, int i) {
+  inputs.push_back(std::make_unique<StreamInput>(new SimpleEventStream(m, i)));
+}
+
+void TurboEventsImpl::run(Output &output) {
   auto greaterES = [](const EventStream *a, const EventStream *b) {
     return a->time > b->time;
   };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,15 +12,12 @@ int main(int argc, char **argv) {
   auto turbo = TurboEvents::TurboEvents::create();
 
   auto output = TurboEvents::TurboEvents::createOutput(FLAGS_output);
-  std::vector<std::unique_ptr<TurboEvents::Input>> inputs;
+  for (int i = 1; i < argc; ++i) turbo->createXMLFileInput(argv[i]);
 
-  for (int i = 1; i < argc; ++i)
-    inputs.push_back(TurboEvents::TurboEvents::createXMLFileInput(argv[i]));
+  turbo->createStreamInput(5);
+  turbo->createStreamInput(2, 1500);
 
-  inputs.push_back(TurboEvents::TurboEvents::createStreamInput(5));
-  inputs.push_back(TurboEvents::TurboEvents::createStreamInput(2, 1500));
-
-  turbo->run(*output, inputs);
+  turbo->run(*output);
 
   gflags::ShutDownCommandLineFlags();
   return 0;


### PR DESCRIPTION
There is no need for inputs to be in
main so store them in an internal
TurboEventsImpl object instead. This
allows us to internalize the abstract
Input class.