### PR TITLE
Put the countdown stream in separate files

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -15,7 +15,7 @@ public:
   /// Create a new XML file input.
   virtual void createXMLFileInput(const char *name) = 0;
   /// Create a new StreamInput object.
-  virtual void createStreamInput(int m, int i = 1000) = 0;
+  virtual void createCountDownInput(int m, int i = 200) = 0;
 
   /// Set the output to print.
   virtual void setPrintOutput() = 0;

--- a/lib/IO/CountDownInput.hpp
+++ b/lib/IO/CountDownInput.hpp
@@ -1,0 +1,48 @@
+#include "turboevents-internal.hpp"
+
+namespace TurboEvents {
+
+/// Event stream that counts down to 0.
+class CountDownEventStream : public EventStream {
+public:
+  /// Constructor
+  CountDownEventStream(int m, int i)
+      : EventStream(nullptr), n(m), interval(i) {}
+
+  bool generate(Output &output) override {
+    if (next != nullptr) delete next;
+    if (n <= 0) return false;
+    next = output.makeEvent(std::chrono::system_clock::now() +
+                                std::chrono::milliseconds(interval),
+                            n);
+    time = next->time;
+    --n;
+    return true;
+  }
+
+private:
+  int n;              ///< How many events to generate
+  const int interval; ///< Interval in ms between events
+};
+
+/// An input class for streams that count down.
+class CountDownInput : public Input {
+public:
+  /// Constructor
+  CountDownInput(int m, int i)
+      : stream(std::make_unique<CountDownEventStream>(m, i)) {}
+
+  virtual ~CountDownInput() {}
+
+  void addStreams(Output &, std::function<void(EventStream *)> push) override {
+    push(stream.get());
+  }
+
+  void finish() override {}
+
+private:
+  /// The event stream
+  std::unique_ptr<EventStream> stream;
+};
+
+} // namespace TurboEvents

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,8 +22,8 @@ int main(int argc, char **argv) {
 
   for (int i = 1; i < argc; ++i) turbo->createXMLFileInput(argv[i]);
 
-  turbo->createStreamInput(5);
-  turbo->createStreamInput(2, 1500);
+  turbo->createCountDownInput(5);
+  turbo->createCountDownInput(2, 300);
 
   turbo->run();
 


### PR DESCRIPTION
A countdown stream has no real world use,
but this code is our current example of algorithmic
generation of events so put it in the right
place in the tree and keep it around for
ensuring we don't get regressions in functionality.

Also divide the used interval values by 5.
This saves us 8 seconds in the CI runs.