### PR TITLE
Add command line parameter for countdown stream

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,9 @@
 
 #include <gflags/gflags.h>
 #include <iostream>
+#include <string>
 
+DEFINE_string(input, "", "comma-separated list of algorithmic input streams");
 DEFINE_string(output, "print", "what kind of events to produce");
 
 int main(int argc, char **argv) {
@@ -22,8 +24,10 @@ int main(int argc, char **argv) {
 
   for (int i = 1; i < argc; ++i) turbo->createXMLFileInput(argv[i]);
 
-  turbo->createCountDownInput(5);
-  turbo->createCountDownInput(2, 300);
+  if (FLAGS_input.find("countdown") != std::string::npos) {
+    turbo->createCountDownInput(5);
+    turbo->createCountDownInput(2, 300);
+  }
 
   turbo->run();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set_tests_properties(test_build PROPERTIES FIXTURES_SETUP test_fixture)
 # Each test to run, and their test_fixture to manage dependencies.
 add_test(NAME xml_test
   COMMAND $<TARGET_FILE:turboevents_main>
+            --input="hello,countdown"
             ${TurboEvents_SOURCE_DIR}/test/events1.xml
             ${TurboEvents_SOURCE_DIR}/test/events2.xml)
 set_tests_properties(xml_test PROPERTIES FIXTURES_REQUIRED test_fixture)


### PR DESCRIPTION
This makes the default behavior of main to only
process xml files given as arguments, the countdown
stream needs to be explicitly enabled.

Also add the flag to the xml_test so we get automatic
test coverage of using two types of streams
at the same time.