### PR TITLE
Enable external configuration of Kafka

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -21,7 +21,7 @@ public:
   /// Set the output to print.
   virtual void setPrintOutput() = 0;
   /// Set the output to Kafka.
-  virtual void setKafkaOutput() = 0;
+  virtual void setKafkaOutput(std::string brokers, std::string topic) = 0;
 
   /// Virtual destructor
   virtual ~TurboEvents();

--- a/lib/IO/KafkaOutput.cpp
+++ b/lib/IO/KafkaOutput.cpp
@@ -16,9 +16,6 @@ public:
 };
 
 void KafkaEvent::trigger() const {
-  std::string brokers = "localhost";
-  std::string topic = "measurements";
-
   std::string errstr;
 
   RdKafka::Conf *c = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);

--- a/lib/IO/KafkaOutput.hpp
+++ b/lib/IO/KafkaOutput.hpp
@@ -10,13 +10,18 @@ namespace TurboEvents {
 class KafkaEvent : public Event {
 public:
   /// Public constructor
-  KafkaEvent(std::chrono::system_clock::time_point t, std::string d)
-      : Event(t), data(d) {}
+  KafkaEvent(std::string broker, std::string top,
+             std::chrono::system_clock::time_point t, std::string d)
+      : Event(t), brokers(broker), topic(top), data(d) {}
 
   /// Implementation of trigger() for Kafka events
   void trigger() const override;
 
 private:
+  /// The brokers for Kafka.
+  std::string brokers;
+  /// The topic to send the data to.
+  std::string topic;
   /// The data to send.
   std::string data;
 };
@@ -24,13 +29,16 @@ private:
 /// Output object that creates Kafka events
 class KafkaOutput : public Output {
 public:
+  /// Constructor.
+  KafkaOutput(std::string broker, std::string top)
+      : brokers(broker), topic(top) {}
   /// Destructor
   virtual ~KafkaOutput() override {}
 
-  /// Make an event that published to a topic
+  /// Make an event that is published to a topic
   Event *makeEvent(std::chrono::system_clock::time_point t,
                    std::string data) override {
-    return new KafkaEvent(t, data);
+    return new KafkaEvent(brokers, topic, t, data);
   }
 
   /// Make an event that prints an int
@@ -38,6 +46,12 @@ public:
     unimp("KafkaOutput", "int");
     return nullptr;
   }
+
+private:
+  /// The brokers for Kafka.
+  std::string brokers;
+  /// The topic to send the data to.
+  std::string topic;
 };
 } // namespace TurboEvents
 #endif

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -24,7 +24,7 @@ public:
   void createCountDownInput(int m, int i) override;
 
   void setPrintOutput() override;
-  void setKafkaOutput() override;
+  void setKafkaOutput(std::string brokers, std::string topic) override;
 
   void run() override;
 
@@ -65,8 +65,8 @@ void TurboEventsImpl::setPrintOutput() {
   output = std::make_unique<PrintOutput>();
 }
 
-void TurboEventsImpl::setKafkaOutput() {
-  output = std::make_unique<KafkaOutput>();
+void TurboEventsImpl::setKafkaOutput(std::string brokers, std::string topic) {
+  output = std::make_unique<KafkaOutput>(brokers, topic);
 }
 
 void TurboEvents::runScript(std::string &file) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,9 @@ DEFINE_string(script, "", "file name for Python script");
 DEFINE_bool(print, false, "print the Python commands and exit");
 DEFINE_string(input, "", "comma-separated list of algorithmic input streams");
 DEFINE_string(output, "print", "what kind of events to produce");
+DEFINE_string(kafka_brokers, "localhost",
+              "comma-separated list of kafka brokers");
+DEFINE_string(kafka_topic, "measurements", "topic to send kafka messages as");
 
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");
@@ -19,7 +22,8 @@ int main(int argc, char **argv) {
   if (FLAGS_output == "print")
     cmds += "t.setPrintOutput()\n";
   else if (FLAGS_output == "kafka")
-    cmds += "t.setKafkaOutput()\n";
+    cmds += "t.setKafkaOutput('" + FLAGS_kafka_brokers + "', '" +
+            FLAGS_kafka_topic + "')\n";
   else {
     std::cerr << "Unknown output: " << FLAGS_output << "\n";
     exit(1);


### PR DESCRIPTION
The previous values for brokers and topic
were hardcoded, make them parameters passed
on from main with the hardcoded values as
defaults instead.