### PR TITLE
Add functionality to time shift file input.

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -14,7 +14,7 @@ public:
   /// Create a new TurboEvents object.
   static std::unique_ptr<TurboEvents> create();
   /// Create a new XML file input.
-  virtual void createXMLFileInput(const char *name) = 0;
+  virtual void createXMLFileInput(const char *name, bool timeshift) = 0;
   /// Create a new StreamInput object.
   virtual void createCountDownInput(int m, int i = 200) = 0;
 

--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -23,7 +23,7 @@ public:
   /// Open an XML-file and add one or more event streams based on its contents
   void addStreamsFromXMLFile(Output &output,
                              std::function<void(EventStream *)> push,
-                             const char *fname);
+                             const char *fname, bool timeshift);
 
 private:
   /// Event stream objects for open streams.
@@ -36,7 +36,7 @@ void XMLFileInput::addStreams(Output &output,
                               std::function<void(EventStream *)> push) {
   // First, ensure that the XML system is up and running.
   if (xmlInput == nullptr) xmlInput = new XMLInput();
-  xmlInput->addStreamsFromXMLFile(output, push, fname.c_str());
+  xmlInput->addStreamsFromXMLFile(output, push, fname.c_str(), tshift);
 }
 
 void XMLFileInput::finish() {
@@ -59,7 +59,7 @@ XMLInput::~XMLInput() {
 
 void XMLInput::addStreamsFromXMLFile(Output &output,
                                      std::function<void(EventStream *)> push,
-                                     const char *fname) {
+                                     const char *fname, bool timeshift) {
   XMLCh tempStr[100];
   XMLString::transcode("LS", tempStr, 99);
   DOMImplementation *impl =
@@ -96,12 +96,15 @@ void XMLInput::addStreamsFromXMLFile(Output &output,
   XMLString::release(&ns);
   XMLString::release(&tag);
 
+  std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+  std::chrono::nanoseconds shift(0);
   std::vector<Event *> events;
   for (XMLSize_t i = 0; i < myList->getLength(); ++i) {
     auto *elem = static_cast<DOMElement *>(myList->item(i));
 
     DOMNodeList *xmlEvents = elem->getElementsByTagName(eventTag);
 
+    bool firstEvent = true;
     for (XMLSize_t idx = 0; idx < xmlEvents->getLength(); ++idx) {
       auto *attrs = xmlEvents->item(idx)->getAttributes();
 
@@ -116,6 +119,11 @@ void XMLInput::addStreamsFromXMLFile(Output &output,
       XMLString::release(&timeStamp);
       auto tp = std::chrono::system_clock::from_time_t(std::mktime(&timeBuf));
 
+      if (firstEvent) {
+        if (timeshift) shift = now - tp;
+        firstEvent = false;
+      }
+      tp += shift;
       events.push_back(output.makeEvent(tp, value));
       // The value string has been converted to a std::string by the call above
       // and is no longer used.

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -9,7 +9,8 @@ namespace TurboEvents {
 class XMLFileInput : public Input {
 public:
   /// Constructor
-  XMLFileInput(const char *fileName) : fname(fileName) {}
+  XMLFileInput(const char *fileName, bool timeshift)
+      : fname(fileName), tshift(timeshift) {}
   virtual ~XMLFileInput() {}
 
   void addStreams(Output &output,
@@ -20,6 +21,8 @@ public:
 private:
   /// The name of the file
   std::string fname;
+  /// Whether to time shift
+  bool tshift;
 };
 
 /// An event stream that is read from an XML file

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -20,7 +20,7 @@ public:
   TurboEventsImpl() : inputs() {}
   ~TurboEventsImpl() {}
 
-  void createXMLFileInput(const char *name) override;
+  void createXMLFileInput(const char *name, bool timeshift) override;
   void createCountDownInput(int m, int i) override;
 
   void setPrintOutput() override;
@@ -53,8 +53,8 @@ std::unique_ptr<TurboEvents> TurboEvents::create() {
   return std::make_unique<TurboEventsImpl>();
 }
 
-void TurboEventsImpl::createXMLFileInput(const char *name) {
-  inputs.push_back(std::make_unique<XMLFileInput>(name));
+void TurboEventsImpl::createXMLFileInput(const char *name, bool timeshift) {
+  inputs.push_back(std::make_unique<XMLFileInput>(name, timeshift));
 }
 
 void TurboEventsImpl::createCountDownInput(int m, int i) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,8 @@ DEFINE_string(output, "print", "what kind of events to produce");
 DEFINE_string(kafka_brokers, "localhost",
               "comma-separated list of kafka brokers");
 DEFINE_string(kafka_topic, "measurements", "topic to send kafka messages as");
+DEFINE_bool(timeshift, false,
+            "shift time stamps in file inputs to start immediately");
 
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");
@@ -29,8 +31,10 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
+  std::string tsArg = FLAGS_timeshift ? "True" : "False";
   for (int i = 1; i < argc; ++i)
-    cmds += "t.createXMLFileInput('" + std::string(argv[i]) + "')\n";
+    cmds +=
+        "t.createXMLFileInput('" + std::string(argv[i]) + "', " + tsArg + ")\n";
 
   if (FLAGS_input.find("countdown") != std::string::npos) {
     cmds += "t.createCountDownInput(5, 200)\n"

--- a/test/events1.xml
+++ b/test/events1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <patient id="0">
   <glucose_level>
-    <event ts="12-01-2022 19:41:00" value="100"/>
-    <event ts="13-01-2022  9:38:30" value="102"/>
+    <event ts="12-01-2022  9:38:00" value="100"/>
+    <event ts="12-01-2022  9:38:01" value="102"/>
   </glucose_level>
 </patient>

--- a/test/events2.xml
+++ b/test/events2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <patient id="1">
   <glucose_level>
-    <event ts="13-01-2022  9:38:00" value="101"/>
-    <event ts="14-01-2022 16:45:15" value="103"/>
+    <event ts="12-01-2022  9:38:00" value="101"/>
+    <event ts="12-01-2022  9:38:25" value="103"/>
   </glucose_level>
 </patient>


### PR DESCRIPTION
The timestamps of events in files are absolute. This requires
the files to be updated for each use, which is inconvenient.
This patch introduces the command line flag --timeshift which
tells turboevents to shift the time stamps in each file by a
constant amount so that the first event in the file is triggered
approximately when the program starts.

The test files are also updated to give a reasonable execution
time for testing with the new flag.