### PR TITLE
Base event time on previous time in CountDownEventStream.

### DIFF
--- a/lib/IO/CountDownInput.hpp
+++ b/lib/IO/CountDownInput.hpp
@@ -7,22 +7,20 @@ class CountDownEventStream : public EventStream {
 public:
   /// Constructor
   CountDownEventStream(int m, int i)
-      : EventStream(nullptr), n(m), interval(i) {}
+      : n(m), interval(std::chrono::milliseconds(i)) {}
 
   bool generate(Output &output) override {
     if (next != nullptr) delete next;
     if (n <= 0) return false;
-    next = output.makeEvent(std::chrono::system_clock::now() +
-                                std::chrono::milliseconds(interval),
-                            n);
-    time = next->time;
+    time += interval;
+    next = output.makeEvent(time, n);
     --n;
     return true;
   }
 
 private:
-  int n;              ///< How many events to generate
-  const int interval; ///< Interval in ms between events
+  int n;                              ///< How many events to generate
+  std::chrono::milliseconds interval; ///< Interval between events
 };
 
 /// An input class for streams that count down.

--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -141,7 +141,7 @@ void XMLInput::addStreamsFromXMLFile(Output &output,
 }
 
 XMLEventStream::XMLEventStream(std::vector<Event *> events)
-    : EventStream(nullptr), eventVec(events), eventIdx(0) {}
+    : eventVec(events), eventIdx(0) {}
 
 bool XMLEventStream::generate(Output &) {
   if (next != nullptr) delete next;

--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -58,7 +58,7 @@ struct Event {
 class EventStream {
 public:
   /// Constructor
-  EventStream(Event *e) : next(e) {}
+  EventStream() : time(std::chrono::system_clock::now()), next(nullptr) {}
   /// Virtual destructor
   virtual ~EventStream() {}
   /// Get next event


### PR DESCRIPTION
This patch ensures that event times are evenly spaced for
CountDownEventStream by basing each time stamp on the
previous time stamp rather than clock time when the event
is generated. This ensures expected behaviour when time
scaling is implemented in a future commit.