### PR TITLE
Add command line option to scale time.

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -34,7 +34,7 @@ public:
   static void runString(std::string &s);
 
   /// Run the event generator and process events.
-  virtual void run() = 0;
+  virtual void run(double scale) = 0;
 };
 
 } // namespace TurboEvents

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,9 @@ DEFINE_string(kafka_key_password, "", "password for the key file");
 DEFINE_string(kafka_topic, "measurements", "topic to send kafka messages as");
 DEFINE_bool(timeshift, false,
             "shift time stamps in file inputs to start immediately");
+DEFINE_double(scale, 1.0,
+              "scaling factor for intervals between events, less than 1 "
+              "accelerates delivery");
 
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");
@@ -47,7 +50,7 @@ int main(int argc, char **argv) {
             "t.createCountDownInput(2, 300)\n";
   }
 
-  cmds += "t.run()\n";
+  cmds += "t.run(" + std::to_string(FLAGS_scale) + ")\n";
   if (FLAGS_print) {
     std::cout << cmds;
     goto out;


### PR DESCRIPTION
This patch adds the option '--scale <x>' which scales the
intervals between generated events by a factor <x>. A scaling
factor of 1 makes no change, a factor above 1 increases the
(real) time between event delivery while a factor below 1
speeds up delivery. A factor of 0 is allowed and delivers
the events as fast as possible.