### PR TITLE
Use unique_ptr for events

### DIFF
--- a/lib/IO/CountDownInput.hpp
+++ b/lib/IO/CountDownInput.hpp
@@ -9,18 +9,18 @@ public:
   CountDownEventStream(int m, int i)
       : n(m), interval(std::chrono::milliseconds(i)) {}
 
+  Event *getEvent() const override { return event.get(); }
+
   bool generate(Output &output) override {
-    if (next != nullptr) delete next;
-    if (n <= 0) return false;
     time += interval;
-    next = output.makeEvent(time, n);
-    --n;
-    return true;
+    event = output.makeEvent(time, n);
+    return n-- > 0;
   }
 
 private:
   int n;                                    ///< How many events to generate
   const std::chrono::milliseconds interval; ///< Interval between events
+  std::unique_ptr<Event> event;             ///< The current event.
 };
 
 /// An input class for streams that count down.

--- a/lib/IO/KafkaOutput.hpp
+++ b/lib/IO/KafkaOutput.hpp
@@ -50,14 +50,15 @@ public:
   virtual ~KafkaOutput() override {}
 
   /// Make an event that is published to a topic
-  Event *makeEvent(std::chrono::system_clock::time_point t,
-                   std::string data) override {
-    return new KafkaEvent(brokers, caLoc, certLoc, keyLoc, keyPw, topic, t,
-                          data);
+  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point t,
+                                   std::string data) override {
+    return std::make_unique<KafkaEvent>(brokers, caLoc, certLoc, keyLoc, keyPw,
+                                        topic, t, data);
   }
 
   /// Make an event that prints an int
-  Event *makeEvent(std::chrono::system_clock::time_point, int) override {
+  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point,
+                                   int) override {
     unimp("KafkaOutput", "int");
     return nullptr;
   }

--- a/lib/IO/PrintOutput.hpp
+++ b/lib/IO/PrintOutput.hpp
@@ -31,14 +31,15 @@ public:
   virtual ~PrintOutput() override {}
 
   /// Make an event that prints a string
-  Event *makeEvent(std::chrono::system_clock::time_point t,
-                   std::string data) override {
-    return new PrintEvent<std::string>(t, data);
+  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point t,
+                                   std::string data) override {
+    return std::make_unique<PrintEvent<std::string>>(t, data);
   }
 
   /// Make an event that prints an int
-  Event *makeEvent(std::chrono::system_clock::time_point t, int data) override {
-    return new PrintEvent<int>(t, data);
+  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point t,
+                                   int data) override {
+    return std::make_unique<PrintEvent<int>>(t, data);
   }
 };
 

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -29,20 +29,21 @@ private:
 class XMLEventStream : public EventStream {
 public:
   /// Constructor
-  XMLEventStream(std::vector<Event *> events);
+  XMLEventStream(std::vector<std::unique_ptr<Event>> events);
 
   /// Destructor
   virtual ~XMLEventStream() {}
 
-  /// Generator
+  Event *getEvent() const override { return eventVec[eventIdx].get(); }
+
   bool generate(Output &output) override;
 
 private:
   /// The events of this stream
-  std::vector<Event *> eventVec;
+  std::vector<std::unique_ptr<Event>> eventVec;
 
-  /// Index of next event to generate
-  size_t eventIdx;
+  /// Index of current event
+  ssize_t eventIdx;
 };
 
 } // namespace TurboEvents

--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace TurboEvents {
@@ -17,11 +18,12 @@ public:
   virtual ~Output() = 0;
 
   /// Virtual function to make an event with a string payload
-  virtual Event *makeEvent(std::chrono::system_clock::time_point,
-                           std::string data) = 0;
+  virtual std::unique_ptr<Event>
+  makeEvent(std::chrono::system_clock::time_point, std::string data) = 0;
 
   /// Virtual function to make an event with an int payload
-  virtual Event *makeEvent(std::chrono::system_clock::time_point, int data) = 0;
+  virtual std::unique_ptr<Event>
+  makeEvent(std::chrono::system_clock::time_point, int data) = 0;
 
 protected:
   /// Common error handling function
@@ -58,22 +60,16 @@ struct Event {
 class EventStream {
 public:
   /// Constructor
-  EventStream() : time(std::chrono::system_clock::now()), next(nullptr) {}
+  EventStream() : time(std::chrono::system_clock::now()) {}
   /// Virtual destructor
   virtual ~EventStream() {}
-  /// Get next event
-  Event *getNext() const { return next; }
+  /// Get the current event.
+  virtual Event *getEvent() const = 0;
 
-  /// Generate the next event and write it to next returning true if an event
-  /// was found
+  /// Try to generate an event, return true if successful.
   virtual bool generate(Output &output) = 0;
-
-  /// The time stamp of the first event
+  /// The time stamp of the current event.
   std::chrono::system_clock::time_point time;
-
-protected:
-  /// The next event
-  Event *next;
 };
 
 } // namespace TurboEvents

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -106,7 +106,7 @@ void TurboEventsImpl::run(double scale) {
     EventStream *es = q.top();
     q.pop();
     std::this_thread::sleep_until(start + scale * (es->time - start));
-    es->getNext()->trigger();
+    es->getEvent()->trigger();
     if (es->generate(*output))
       q.push(es); // Push the stream back on the queue if there are more events
   }


### PR DESCRIPTION
This required some restructing, each
subclass to EventStream now keeps track
of their events and returns the current
event with getEvent(). This also allowed
the event time to only be stored in events
which simplified the generate() method
for all event producers.