### PR TITLE
Add a general input container

### DIFF
--- a/.github/workflows/adapted-cmake.yml
+++ b/.github/workflows/adapted-cmake.yml
@@ -56,6 +56,7 @@ jobs:
 
     - name: Test
       run: |
+        cmake --build ${{github.workspace}}/build --config Release --target check
+        # Sanitizers/Valgrind needs Python to use the regular malloc.
         export PYTHONMALLOC=malloc
         cmake --build ${{github.workspace}}/build --config Debug --target check
-        cmake --build ${{github.workspace}}/build --config Release --target check

--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -1,6 +1,7 @@
 #ifndef TURBOEVENTS_HPP
 #define TURBOEVENTS_HPP
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -11,22 +12,25 @@ class TurboEvents {
 public:
   /// Simple constructor
   TurboEvents();
+  /// Virtual destructor
+  virtual ~TurboEvents();
+
   /// Create a new TurboEvents object.
   static std::unique_ptr<TurboEvents> create();
-  /// Create a new XML file input.
-  virtual void createXMLFileInput(const char *name, bool timeshift) = 0;
+
+  /// Create an input from the previous calls to addEvent.
+  virtual void createContainerInput() = 0;
   /// Create a new StreamInput object.
   virtual void createCountDownInput(int m, int i = 200) = 0;
+  /// Create a new XML file input.
+  virtual void createXMLFileInput(const char *name, bool timeshift) = 0;
 
-  /// Set the output to print.
-  virtual void setPrintOutput() = 0;
   /// Set the output to Kafka.
   virtual void setKafkaOutput(std::string brokers, std::string caLocation,
                               std::string certLocation, std::string keyLocation,
                               std::string keyPwd, std::string topic) = 0;
-
-  /// Virtual destructor
-  virtual ~TurboEvents();
+  /// Set the output to print.
+  virtual void setPrintOutput() = 0;
 
   /// Run the file in Python.
   static void runScript(std::string &file);
@@ -35,6 +39,10 @@ public:
 
   /// Run the event generator and process events.
   virtual void run(double scale) = 0;
+
+  /// Add an event to an internal container.
+  virtual void addEvent(std::chrono::system_clock::time_point time,
+                        std::string data) = 0;
 };
 
 } // namespace TurboEvents

--- a/lib/IO/ContainerInput.hpp
+++ b/lib/IO/ContainerInput.hpp
@@ -1,0 +1,51 @@
+#ifndef CONTAINERINPUT_HPP
+#define CONTAINERINPUT_HPP
+
+#include "turboevents-internal.hpp"
+
+namespace TurboEvents {
+
+/// Event stream that generates events from a container.
+class ContainerStream : public EventStream {
+public:
+  /// Constructor
+  ContainerStream(std::vector<std::unique_ptr<Event>> v)
+      : events(std::move(v)), ix(-1) {}
+  virtual ~ContainerStream() {}
+
+  Event *getEvent() const override { return events[ix].get(); }
+
+  bool generate(Output &) override {
+    // FIXME: (Clang-13) Use std::ssize(events) in RHS instead casting LHS.
+    if (static_cast<size_t>(++ix) >= events.size()) return false;
+    time = events[ix]->time;
+    return true;
+  }
+
+private:
+  std::vector<std::unique_ptr<Event>> events; ///< The events of the stream.
+  ssize_t ix;                                 ///< Index of current event.
+};
+
+/// An input class for streams triggering events from an internal container.
+class ContainerInput : public Input {
+public:
+  /// Constructor
+  ContainerInput(std::vector<std::unique_ptr<Event>> v)
+      : stream(std::make_unique<ContainerStream>(std::move(v))) {}
+
+  virtual ~ContainerInput() {}
+
+  void addStreams(Output &, std::function<void(EventStream *)> push) override {
+    push(stream.get());
+  }
+
+  void finish() override {}
+
+private:
+  std::unique_ptr<EventStream> stream; ///< The event stream.
+};
+
+} // namespace TurboEvents
+
+#endif

--- a/lib/IO/CountDownInput.hpp
+++ b/lib/IO/CountDownInput.hpp
@@ -1,3 +1,6 @@
+#ifndef COUNTDOWNINPUT_HPP
+#define COUNTDOWNINPUT_HPP
+
 #include "turboevents-internal.hpp"
 
 namespace TurboEvents {
@@ -44,3 +47,5 @@ private:
 };
 
 } // namespace TurboEvents
+
+#endif

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -1,7 +1,7 @@
 #ifndef XMLINPUT_HPP
 #define XMLINPUT_HPP
 
-#include "turboevents-internal.hpp"
+#include "ContainerInput.hpp"
 
 namespace TurboEvents {
 
@@ -23,27 +23,6 @@ private:
   std::string fname;
   /// Whether to time shift
   bool tshift;
-};
-
-/// An event stream that is read from an XML file
-class XMLEventStream : public EventStream {
-public:
-  /// Constructor
-  XMLEventStream(std::vector<std::unique_ptr<Event>> events);
-
-  /// Destructor
-  virtual ~XMLEventStream() {}
-
-  Event *getEvent() const override { return eventVec[eventIdx].get(); }
-
-  bool generate(Output &output) override;
-
-private:
-  /// The events of this stream
-  std::vector<std::unique_ptr<Event>> eventVec;
-
-  /// Index of current event
-  ssize_t eventIdx;
 };
 
 } // namespace TurboEvents

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,7 +2,8 @@ include(CTest)
 
 include(ProcessorCount)
 ProcessorCount(N)
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -j${N})
+add_custom_target(check
+  COMMAND ${CMAKE_CTEST_COMMAND} -C $<CONFIG> -j${N} --output-on-failure)
 
 # Test fixture to build the main binary which is required by most tests.
 add_test(NAME test_build
@@ -18,3 +19,8 @@ add_test(NAME xml_test
             ${TurboEvents_SOURCE_DIR}/test/events1.xml
             ${TurboEvents_SOURCE_DIR}/test/events2.xml)
 set_tests_properties(xml_test PROPERTIES FIXTURES_REQUIRED test_fixture)
+
+add_test(NAME container_test
+  COMMAND $<TARGET_FILE:turboevents_main>
+            --script ${TurboEvents_SOURCE_DIR}/test/containerinput.py)
+set_tests_properties(container_test PROPERTIES FIXTURES_REQUIRED test_fixture)

--- a/test/containerinput.py
+++ b/test/containerinput.py
@@ -1,0 +1,10 @@
+import datetime
+import time
+import TurboEvents
+t = TurboEvents.TurboEvents()
+t.setPrintOutput()
+t.addEvent(datetime.datetime.fromtimestamp(time.time()), 'Hello,')
+time.sleep(0.3)
+t.addEvent(datetime.datetime.fromtimestamp(time.time()), 'World!')
+t.createContainerInput()
+t.run(1.000000)


### PR DESCRIPTION
This adds an input container that can
be used from the Python API. This turned
out to be the same container that XMLInput
has already implemented so move the relevant
XMLInput code into a separate file and use
that from XMLInput.

The natural API would be

createContainerInput(std::vector<std::unique_ptr<>> evs)

but that does not work with Pybind, so remove
the parameter and hide a container inside
TurboEventsImpl that can be accessed through
addEvent() in the public API.

This commit also groups the related methods
and sorts them in alphabetical order.