### PR TITLE
Move time to Output object

### DIFF
--- a/lib/IO/XMLInput.cpp
+++ b/lib/IO/XMLInput.cpp
@@ -26,8 +26,6 @@ public:
                              const char *fname, bool timeshift);
 
 private:
-  /// The start time for the XML subsystem.
-  std::chrono::system_clock::time_point now;
   /// Event stream objects for open streams.
   std::vector<std::unique_ptr<ContainerStream>> streams;
 };
@@ -41,7 +39,7 @@ void XMLFileInput::addStreams(Output &output,
   xmlInput->addStreamsFromXMLFile(output, push, fname.c_str(), tshift);
 }
 
-XMLInput::XMLInput() : now(std::chrono::system_clock::now()) {
+XMLInput::XMLInput() {
   try {
     XMLPlatformUtils::Initialize();
   } catch (const XMLException &e) {
@@ -125,7 +123,7 @@ void XMLInput::addStreamsFromXMLFile(Output &output,
         auto tp = std::chrono::system_clock::from_time_t(std::mktime(&timeBuf));
 
         if (firstEvent) {
-          if (timeshift) shift = now - tp;
+          if (timeshift) shift = output.start - tp;
           firstEvent = false;
         }
         tp += shift;

--- a/lib/turboevents-internal.hpp
+++ b/lib/turboevents-internal.hpp
@@ -19,6 +19,7 @@ extern uint64_t streamNum;
 /// A class encapsulating an output destination
 class Output {
 public:
+  Output() : start(std::chrono::system_clock::now()) {}
   /// Virtual destructor
   virtual ~Output() = default;
 
@@ -29,6 +30,9 @@ public:
   /// Virtual function to make an event with an int payload
   virtual std::unique_ptr<Event>
   makeEvent(std::chrono::system_clock::time_point, int data) = 0;
+
+  /// The start time of the output object.
+  const std::chrono::system_clock::time_point start;
 
 protected:
   /// Common error handling function

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -118,7 +118,7 @@ void TurboEventsImpl::run(double scale) {
     if (s->generate(*output)) q.push(s);
   };
   for (auto &input : inputs) input->addStreams(*output, push);
-  auto start = std::chrono::system_clock::now();
+  const auto start = output->start;
   while (!q.empty()) {
     EventStream *es = q.top();
     q.pop();


### PR DESCRIPTION
This gives a single global time
to be used for the time shifting
in any kind of input.