### PR TITLE
Add xml_control option.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,-llvm-header-guard'
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,readability-identifier-naming,-llvm-header-guard'
 WarningsAsErrors: '*'
 HeaderFilterRegex: '.*'
 CheckOptions:

--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -23,7 +23,7 @@ public:
   /// Create a new StreamInput object.
   virtual void createCountDownInput(int m, int i = 200) = 0;
   /// Create a new XML file input.
-  virtual void createXMLFileInput(const char *name) = 0;
+  virtual void createXMLFileInput(const char *name, const char *ctrl) = 0;
 
   /// Set the output to Kafka.
   virtual void setKafkaOutput(bool timeshift, std::string brokers,

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -9,7 +9,8 @@ namespace TurboEvents {
 class XMLFileInput : public Input {
 public:
   /// Constructor
-  XMLFileInput(const char *fileName) : fname(fileName) {}
+  XMLFileInput(const char *fileName, const char *ctrl)
+      : fname(fileName), control(ctrl) {}
   virtual ~XMLFileInput() {}
 
   void addStreams(Output &output,
@@ -20,6 +21,8 @@ public:
 private:
   /// The name of the file
   std::string fname;
+  /// What information to extract from the XML file
+  std::string control;
 };
 
 } // namespace TurboEvents

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -24,7 +24,7 @@ public:
 
   void createContainerInput() override;
   void createCountDownInput(int m, int i) override;
-  void createXMLFileInput(const char *name) override;
+  void createXMLFileInput(const char *name, const char *ctrl) override;
 
   void setKafkaOutput(bool timeshift, std::string brokers,
                       std::string caLocation, std::string certLocation,
@@ -74,8 +74,8 @@ void TurboEventsImpl::createCountDownInput(int m, int i) {
   inputs.push_back(std::make_unique<CountDownInput>(m, i));
 }
 
-void TurboEventsImpl::createXMLFileInput(const char *name) {
-  inputs.push_back(std::make_unique<XMLFileInput>(name));
+void TurboEventsImpl::createXMLFileInput(const char *name, const char *ctrl) {
+  inputs.push_back(std::make_unique<XMLFileInput>(name, ctrl));
 }
 
 void TurboEventsImpl::setKafkaOutput(bool timeshift, std::string brokers,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,8 @@ DEFINE_bool(timeshift, false,
 DEFINE_double(scale, 1.0,
               "scaling factor for intervals between events, less than 1 "
               "accelerates delivery");
+DEFINE_string(xml_ctrl, "patient:id/glucose_level/event:ts:value",
+              "what to extract from xml file");
 
 int main(int argc, char **argv) {
   gflags::SetUsageMessage("fast event generator");
@@ -41,8 +43,10 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
+  std::string ctrl(FLAGS_xml_ctrl);
   for (int i = 1; i < argc; ++i)
-    cmds += "t.createXMLFileInput('" + std::string(argv[i]) + "')\n";
+    cmds += "t.createXMLFileInput('" + std::string(argv[i]) + "', '" + ctrl +
+            "')\n";
 
   if (FLAGS_input.find("countdown") != std::string::npos) {
     cmds += "t.createCountDownInput(5, 200)\n"


### PR DESCRIPTION
This patch adds an option to control which event streams to
generate from XML file inputs. The generated events will have
CSV payloads with parts specified by the control string.