### PR TITLE
Use a second vector in the XML control API

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -24,8 +24,9 @@ public:
   /// Create a new StreamInput object.
   virtual void createCountDownInput(int m, int i = 200) = 0;
   /// Create a new XML file input.
-  virtual void createXMLFileInput(const char *name,
-                                  std::vector<std::string> &ctrl) = 0;
+  virtual void
+  createXMLFileInput(const char *name,
+                     std::vector<std::vector<std::string>> &ctrl) = 0;
 
   /// Set the output to Kafka.
   virtual void setKafkaOutput(bool timeshift, std::string brokers,

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -9,7 +9,8 @@ namespace TurboEvents {
 class XMLFileInput : public Input {
 public:
   /// Constructor
-  XMLFileInput(const char *fileName, std::vector<std::string> &ctrl)
+  XMLFileInput(const char *fileName,
+               std::vector<std::vector<std::string>> &ctrl)
       : fname(fileName), control(ctrl) {}
   virtual ~XMLFileInput() {}
 
@@ -22,7 +23,7 @@ private:
   /// The name of the file
   std::string fname;
   /// What information to extract from the XML file
-  std::vector<std::string> control;
+  std::vector<std::vector<std::string>> control;
 };
 
 } // namespace TurboEvents

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -27,7 +27,7 @@ public:
   void createContainerInput() override;
   void createCountDownInput(int m, int i) override;
   void createXMLFileInput(const char *name,
-                          std::vector<std::string> &ctrl) override;
+                          std::vector<std::vector<std::string>> &ctrl) override;
 
   void setKafkaOutput(bool timeshift, std::string brokers,
                       std::string caLocation, std::string certLocation,
@@ -77,8 +77,8 @@ void TurboEventsImpl::createCountDownInput(int m, int i) {
   inputs.push_back(std::make_unique<CountDownInput>(m, i));
 }
 
-void TurboEventsImpl::createXMLFileInput(const char *name,
-                                         std::vector<std::string> &ctrl) {
+void TurboEventsImpl::createXMLFileInput(
+    const char *name, std::vector<std::vector<std::string>> &ctrl) {
   inputs.push_back(std::make_unique<XMLFileInput>(name, ctrl));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,13 +45,23 @@ int main(int argc, char **argv) {
   }
 
   { // Deal with the xml_ctrl flag and corresponding XML inputs.
-    std::vector<std::string> xmlCtrl;
+    std::vector<std::vector<std::string>> xmlCtrl;
     std::istringstream iss(FLAGS_xml_ctrl);
     std::string item;
-    while (std::getline(iss, item, ',')) xmlCtrl.push_back(item);
+    while (std::getline(iss, item, ',')) {
+      std::vector<std::string> xmlCtrl2;
+      std::istringstream iss2(item);
+      std::string item2;
+      while (std::getline(iss2, item2, '/')) xmlCtrl2.push_back(item2);
+      xmlCtrl.push_back(xmlCtrl2);
+    }
     for (int i = 1; i < argc; ++i) {
       cmds += "t.createXMLFileInput('" + std::string(argv[i]) + "', [";
-      for (auto &ctrl : xmlCtrl) cmds += "'" + ctrl + "', ";
+      for (auto &ctrl : xmlCtrl) {
+        cmds += "[";
+        for (auto &ctrl2 : ctrl) cmds += "'" + ctrl2 + "', ";
+        cmds += "], ";
+      }
       cmds += "])\n";
     }
   }


### PR DESCRIPTION
Add a second vector as structure to the API and let
main perform even more of the input string parsing.

This uncovered that an early return for the case
when nodes is null could be added which removed
some logic from the rest of addStreamsFromNode().