### PR TITLE
Add support for multiple outputs

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -17,7 +17,7 @@ public:
   virtual ~TurboEvents();
 
   /// Create a new TurboEvents object.
-  static std::unique_ptr<TurboEvents> create();
+  static std::unique_ptr<TurboEvents> create(bool timeshift);
 
   /// Create an input from the previous calls to addEvent.
   virtual void createContainerInput() = 0;
@@ -28,13 +28,12 @@ public:
   createXMLFileInput(const char *name,
                      std::vector<std::vector<std::string>> &ctrl) = 0;
 
-  /// Set the output to Kafka.
-  virtual void setKafkaOutput(bool timeshift, std::string brokers,
-                              std::string caLocation, std::string certLocation,
-                              std::string keyLocation, std::string keyPwd,
-                              std::string topic) = 0;
-  /// Set the output to print.
-  virtual void setPrintOutput(bool timeshift) = 0;
+  /// Add a Kafka output.
+  virtual void addKafkaOutput(std::string brokers, std::string caLocation,
+                              std::string certLocation, std::string keyLocation,
+                              std::string keyPwd, std::string topic) = 0;
+  /// Add a print output.
+  virtual void addPrintOutput() = 0;
 
   /// Run the file in Python.
   static void runScript(std::string &file);

--- a/lib/IO/ContainerInput.hpp
+++ b/lib/IO/ContainerInput.hpp
@@ -15,7 +15,7 @@ public:
 
   Event *getEvent() const override { return events[ix].get(); }
 
-  bool generate(Output &) override {
+  bool generate(Config &) override {
     // FIXME: (Clang-13) Use std::ssize(events) in RHS instead casting LHS.
     if (static_cast<size_t>(++ix) >= events.size()) return false;
     time = events[ix]->time;
@@ -36,7 +36,7 @@ public:
 
   virtual ~ContainerInput() {}
 
-  void addStreams(Output &, std::function<void(EventStream *)> push) override {
+  void addStreams(Config &, std::function<void(EventStream *)> push) override {
     push(stream.get());
   }
 

--- a/lib/IO/CountDownInput.hpp
+++ b/lib/IO/CountDownInput.hpp
@@ -14,9 +14,9 @@ public:
 
   Event *getEvent() const override { return event.get(); }
 
-  bool generate(Output &output) override {
+  bool generate(Config &cfg) override {
     time += interval;
-    event = output.makeEvent(time, n);
+    event = cfg.makeEvent(time, n);
     return n-- > 0;
   }
 
@@ -35,7 +35,7 @@ public:
 
   virtual ~CountDownInput() {}
 
-  void addStreams(Output &, std::function<void(EventStream *)> push) override {
+  void addStreams(Config &, std::function<void(EventStream *)> push) override {
     push(stream.get());
   }
 

--- a/lib/IO/KafkaOutput.cpp
+++ b/lib/IO/KafkaOutput.cpp
@@ -15,7 +15,7 @@ public:
   }
 };
 
-void KafkaEvent::trigger() const {
+void KafkaOutput::trigger(Event &e) {
   std::string errstr;
 
   RdKafka::Conf *c = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
@@ -59,9 +59,10 @@ void KafkaEvent::trigger() const {
   delete c;
 
 retry:
-  RdKafka::ErrorCode err = p->produce(
-      topic, RdKafka::Topic::PARTITION_UA, RdKafka::Producer::RK_MSG_COPY,
-      const_cast<char *>(data.c_str()), data.size(), NULL, 0, 0, NULL, NULL);
+  RdKafka::ErrorCode err = p->produce(topic, RdKafka::Topic::PARTITION_UA,
+                                      RdKafka::Producer::RK_MSG_COPY,
+                                      const_cast<char *>(e.data.c_str()),
+                                      e.data.size(), NULL, 0, 0, NULL, NULL);
 
   if (err != RdKafka::ERR_NO_ERROR) {
     std::cerr << "% Failed to produce to topic " << topic << ": "

--- a/lib/IO/KafkaOutput.hpp
+++ b/lib/IO/KafkaOutput.hpp
@@ -6,62 +6,19 @@
 
 namespace TurboEvents {
 
-/// Class for sending Kafka events.
-class KafkaEvent : public Event {
-public:
-  /// Public constructor
-  KafkaEvent(std::string broker, std::string caLocation,
-             std::string certLocation, std::string keyLocation,
-             std::string keyPwd, std::string top,
-             std::chrono::system_clock::time_point t, std::string d)
-      : Event(t), brokers(broker), caLoc(caLocation), certLoc(certLocation),
-        keyLoc(keyLocation), keyPw(keyPwd), topic(top), data(d) {}
-
-  /// Implementation of trigger() for Kafka events
-  void trigger() const override;
-
-private:
-  /// The brokers for Kafka.
-  std::string brokers;
-  /// The ca location.
-  std::string caLoc;
-  /// The certificate location.
-  std::string certLoc;
-  /// The key location.
-  std::string keyLoc;
-  /// The key password.
-  std::string keyPw;
-  /// The topic to send the data to.
-  std::string topic;
-  /// The data to send.
-  std::string data;
-};
-
 /// Output object that creates Kafka events
 class KafkaOutput : public Output {
 public:
   /// Constructor.
-  KafkaOutput(bool timeshift, std::string broker, std::string caLocation,
+  KafkaOutput(std::string broker, std::string caLocation,
               std::string certLocation, std::string keyLocation,
               std::string keyPwd, std::string top)
-      : Output(timeshift), brokers(broker), caLoc(caLocation),
-        certLoc(certLocation), keyLoc(keyLocation), keyPw(keyPwd), topic(top) {}
+      : brokers(broker), caLoc(caLocation), certLoc(certLocation),
+        keyLoc(keyLocation), keyPw(keyPwd), topic(top) {}
   /// Destructor
   virtual ~KafkaOutput() override {}
 
-  /// Make an event that is published to a topic
-  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point t,
-                                   std::string data) override {
-    return std::make_unique<KafkaEvent>(brokers, caLoc, certLoc, keyLoc, keyPw,
-                                        topic, t, data);
-  }
-
-  /// Make an event that prints an int
-  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point,
-                                   int) override {
-    unimp("KafkaOutput", "int");
-    return nullptr;
-  }
+  virtual void trigger(Event &e) override;
 
 private:
   /// The brokers for Kafka.

--- a/lib/IO/PrintOutput.hpp
+++ b/lib/IO/PrintOutput.hpp
@@ -7,42 +7,16 @@
 
 namespace TurboEvents {
 
-/// Event that prints its data to standard output.
-template <typename T> class PrintEvent : public Event {
-public:
-  /// Constructor
-  PrintEvent(std::chrono::system_clock::time_point t, T data)
-      : Event(t), d(data) {}
-
-  /// Destructor
-  virtual ~PrintEvent() override {}
-
-  /// Prints the data to standard output.
-  void trigger() const override { std::cout << d << "\n"; }
-
-private:
-  const T d; ///< Value to print
-};
-
 /// Output object that creates PrintObject
 class PrintOutput : public Output {
 public:
   /// Constructor
-  PrintOutput(bool timeshift) : Output(timeshift) {}
+  PrintOutput() {}
   /// Destructor
   virtual ~PrintOutput() override {}
 
-  /// Make an event that prints a string
-  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point t,
-                                   std::string data) override {
-    return std::make_unique<PrintEvent<std::string>>(t, data);
-  }
-
-  /// Make an event that prints an int
-  std::unique_ptr<Event> makeEvent(std::chrono::system_clock::time_point t,
-                                   int data) override {
-    return std::make_unique<PrintEvent<int>>(t, data);
-  }
+  /// Prints the data to standard output.
+  void trigger(Event &e) override { std::cout << e.data << "\n"; }
 };
 
 } // namespace TurboEvents

--- a/lib/IO/XMLInput.hpp
+++ b/lib/IO/XMLInput.hpp
@@ -14,7 +14,7 @@ public:
       : fname(fileName), control(ctrl) {}
   virtual ~XMLFileInput() {}
 
-  void addStreams(Output &output,
+  void addStreams(Config &cfg,
                   std::function<void(EventStream *)> push) override;
 
   void finish() override {}

--- a/test/containerinput.py
+++ b/test/containerinput.py
@@ -1,8 +1,8 @@
 import datetime
 import time
 import TurboEvents
-t = TurboEvents.TurboEvents()
-t.setPrintOutput(False)
+t = TurboEvents.TurboEvents(False)
+t.addPrintOutput()
 t.addEvent(datetime.datetime.fromtimestamp(time.time()), 'Hello,')
 time.sleep(0.3)
 t.addEvent(datetime.datetime.fromtimestamp(time.time()), 'World!')


### PR DESCRIPTION
This converts the single output into
a container of multiple outputs that
events are sent to. The key insight
is that we need to separate the event data
and the actor that uses the data.

The consequence of that movement is that we
get mulitple output objects, so we also get
multiple starttime/timeshift statuses. Move
that information into a new class "Config"
that we only have a single instance of
(the TurboEventsImpl object). This class
is also a conveient place for the "makeEvent"
methods.

There is nothing that prevents having the same output
multiple times, so:

turboevents test/*xml -output='print,print'

will print the data to stdout twice and:

turboevents test/*xml -output='print,kafka,print'

will print the data, send it through kafka, and
then print it again.

Beyond the functional improvement, the net result
of the change is removing a bunch of overloading
and 5% of the lines of code.