### PR TITLE
Make makeEvent() variadic

### DIFF
--- a/include/turboevents.hpp
+++ b/include/turboevents.hpp
@@ -17,7 +17,7 @@ public:
   virtual ~TurboEvents();
 
   /// Create a new TurboEvents object.
-  static std::unique_ptr<TurboEvents> create(bool timeshift);
+  static std::unique_ptr<TurboEvents> create(char separator, bool timeshift);
 
   /// Create an input from the previous calls to addEvent.
   virtual void createContainerInput() = 0;

--- a/lib/IO/CountDownInput.hpp
+++ b/lib/IO/CountDownInput.hpp
@@ -16,7 +16,7 @@ public:
 
   bool generate(Config &cfg) override {
     time += interval;
-    event = cfg.makeEvent(time, n);
+    event = cfg.makeEvent(time, n, n + 1);
     return n-- > 0;
   }
 

--- a/lib/IO/Serializers.hpp
+++ b/lib/IO/Serializers.hpp
@@ -1,0 +1,29 @@
+#ifndef SERIALIZERS_HPP
+#define SERIALIZERS_HPP
+
+#include <sstream>
+
+namespace TurboEvents {
+
+/// Format arguments into a string separated by a character.
+class JoinFormat {
+public:
+  /// Constructor.
+  JoinFormat(char separator) : sep(separator) {}
+  virtual ~JoinFormat() = default;
+
+  /// Join arguments into a string separated by sep.
+  template <typename H, typename... T>
+  std::string serialize(H &&u, T &&...args) {
+    std::stringstream s;
+    ((s << u) << ... << (s << sep, args));
+    return s.str();
+  }
+
+private:
+  char sep; ///< Separator to use in join.
+};
+
+} // namespace TurboEvents
+
+#endif

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -21,8 +21,8 @@ uint64_t streamNum = 0;
 class TurboEventsImpl : public Config, public TurboEvents {
 public:
   /// Constructor.
-  TurboEventsImpl(bool timeshift)
-      : Config(std::chrono::system_clock::now(), timeshift), outputs(),
+  TurboEventsImpl(char sep, bool timeshift)
+      : Config(sep, std::chrono::system_clock::now(), timeshift), outputs(),
         inputs() {}
   ~TurboEventsImpl() {}
 
@@ -52,7 +52,7 @@ private:
 
 PYBIND11_EMBEDDED_MODULE(TurboEvents, m) {
   py::class_<TurboEventsImpl>(m, "TurboEvents")
-      .def(py::init<bool>())
+      .def(py::init<char, bool>())
       .def("createContainerInput", &TurboEventsImpl::createContainerInput)
       .def("createCountDownInput", &TurboEventsImpl::createCountDownInput)
       .def("createXMLFileInput", &TurboEventsImpl::createXMLFileInput)
@@ -66,8 +66,8 @@ TurboEvents::TurboEvents() {}
 
 TurboEvents::~TurboEvents() = default;
 
-std::unique_ptr<TurboEvents> TurboEvents::create(bool timeshift) {
-  return std::make_unique<TurboEventsImpl>(timeshift);
+std::unique_ptr<TurboEvents> TurboEvents::create(char sep, bool timeshift) {
+  return std::make_unique<TurboEventsImpl>(sep, timeshift);
 }
 
 void TurboEventsImpl::createContainerInput() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,10 +5,26 @@
 #include <sstream>
 #include <string>
 
+static bool validateSeparator(const char *flag, const std::string &value) {
+  if (value.size() == 1) return true;
+  std::cout << "Parameter " << flag << " expects a single character\n";
+  return false;
+}
+
+// Core parameters.
 DEFINE_string(script, "", "file name for Python script");
 DEFINE_bool(print, false, "print the Python commands and exit");
 DEFINE_string(input, "", "comma-separated list of algorithmic input streams");
 DEFINE_string(output, "print", "comma-separated list of outputs");
+DEFINE_string(separator, ",", "separator for serialization");
+DEFINE_validator(separator, &validateSeparator);
+DEFINE_bool(timeshift, false,
+            "shift time stamps in file inputs to start immediately");
+DEFINE_double(scale, 1.0,
+              "scaling factor for intervals between events, less than 1 "
+              "accelerates delivery");
+
+// IO parameters, sorted alphabetically.
 DEFINE_string(kafka_brokers, "localhost",
               "comma-separated list of kafka brokers");
 DEFINE_string(kafka_ca_file, "", "path to ca file");
@@ -16,11 +32,6 @@ DEFINE_string(kafka_certificate_file, "", "path to certificate file");
 DEFINE_string(kafka_key_file, "", "path to key file");
 DEFINE_string(kafka_key_password, "", "password for the key file");
 DEFINE_string(kafka_topic, "measurements", "topic to send kafka messages as");
-DEFINE_bool(timeshift, false,
-            "shift time stamps in file inputs to start immediately");
-DEFINE_double(scale, 1.0,
-              "scaling factor for intervals between events, less than 1 "
-              "accelerates delivery");
 DEFINE_string(xml_ctrl, "patient:id/glucose_level/event:ts:value",
               "what to extract from xml file");
 
@@ -31,7 +42,8 @@ int main(int argc, char **argv) {
 
   std::string cmds("import TurboEvents\n");
   std::string tsArg = FLAGS_timeshift ? "True" : "False";
-  cmds += "t = TurboEvents.TurboEvents(" + tsArg + ")\n";
+  cmds +=
+      "t = TurboEvents.TurboEvents('" + FLAGS_separator + "', " + tsArg + ")\n";
 
   { // Deal with the output flag.
     std::istringstream iss(FLAGS_output);

--- a/test/containerinput.py
+++ b/test/containerinput.py
@@ -1,7 +1,7 @@
 import datetime
 import time
 import TurboEvents
-t = TurboEvents.TurboEvents(False)
+t = TurboEvents.TurboEvents(',', False)
 t.addPrintOutput()
 t.addEvent(datetime.datetime.fromtimestamp(time.time()), 'Hello,')
 time.sleep(0.3)


### PR DESCRIPTION
This adds a serializer component that will
join the arguments with a separator. Update
CountDownInput to generate two numbers so we
get an in-tree user.

Calls to makeEvent with a single datum will
work the same way as before.