### PR TITLE
Add SEGV signal handler

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,4 +25,11 @@ endif()
 find_package(pybind11 REQUIRED)
 target_link_libraries(turboevents PUBLIC pybind11::embed)
 
+if(WIN32)
+    # FIXME: Add stack overflow detection on Windows.
+    # target_sources(turboevents PRIVATE signals-windows.cpp)
+else()
+    target_sources(turboevents PRIVATE signals-unix.cpp)
+endif()
+
 add_subdirectory(IO)

--- a/lib/signals-unix.cpp
+++ b/lib/signals-unix.cpp
@@ -1,0 +1,33 @@
+#define _XOPEN_SOURCE 700
+#include <signal.h>
+#include <unistd.h>
+
+namespace TurboEvents {
+
+void segvHandler(int) {
+  // write() has a __attribute__((warn_unused_result)), and the usual
+  // "trick" of casting to void is deliberately ignored by GCC.
+  // This choice has been discussed since 2005.
+  //
+  // There is no recovery from SIGSEGV at this stage, add a dummy
+  // variable that is unused to silence GCC.
+  [[maybe_unused]] auto dummy = write(2, "stack overflow\n", 15);
+  _exit(127);
+}
+
+void installSegvHandler() {
+  static char stack[SIGSTKSZ];
+  stack_t ss = {
+      .ss_sp = stack,
+      .ss_flags = 0,
+      .ss_size = SIGSTKSZ,
+  };
+  sigaltstack(&ss, NULL);
+  struct sigaction sa;
+  sa.sa_handler = segvHandler;
+  sigfillset(&sa.sa_mask);
+  sa.sa_flags = SA_ONSTACK;
+  sigaction(SIGSEGV, &sa, NULL);
+}
+
+} // namespace TurboEvents

--- a/lib/turboevents.cpp
+++ b/lib/turboevents.cpp
@@ -62,7 +62,10 @@ PYBIND11_EMBEDDED_MODULE(TurboEvents, m) {
       .def("addEvent", &TurboEventsImpl::addEvent);
 }
 
-TurboEvents::TurboEvents() {}
+TurboEvents::TurboEvents() {
+  void installSegvHandler();
+  installSegvHandler();
+}
 
 TurboEvents::~TurboEvents() = default;
 


### PR DESCRIPTION
This adds a signal handler for SEGV
so the user gets a message that
turbo-events ran out of stack.